### PR TITLE
feat(chat): open a native CLI chat with its transcript

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -148,6 +148,7 @@ Neither hook may open an `EventSource` of its own.
 | --- | --- |
 | Run/turn lifecycle, spawning a CLI, streaming stdout | `server/executor.ts` |
 | Per-CLI differences: headless invocation, session id, resume, model/effort flags | `server/resume.ts`, `lib/models.ts` |
+| Adopting a chat started in the CLI itself | `lib/nativeSessions.ts` + `server/nativeSessions.ts` (find them), `lib/nativeTranscript.ts` + `server/nativeTranscript.ts` (read one in full), `server/nativeImport.ts` (write it into a run), `executor.adoptNativeChat` (adopt without prompting); picker in `components/NativeSessionMenu.tsx` |
 | Continuing a chat on another runtime (Claude ⇄ Codex handoff) | `lib/runtimeSwitch.ts` (the rules), `lib/handoffPrompt.ts` (what the new agent is told), `executor.sendFollowUp` (the switch); picker + one-time note in `components/Chat.tsx` |
 | Which models a picker offers | `server/modelCatalog.ts` (cache + refresh), `lib/modelDiscovery.ts` (per-CLI parsers); `lib/models.ts` is only the fallback seed |
 | Hiding models from the picker | `visibleModels` / `hiddenModelsIn` / `toggleHiddenModel` in `lib/models.ts`; stored as `hiddenModels` in `lib/pickerPrefs.ts` (localStorage, display-only — the server never reads it) |

--- a/changelog.d/native-chat-transcript-import.md
+++ b/changelog.d/native-chat-transcript-import.md
@@ -1,0 +1,12 @@
+- A chat you started in Claude Code itself is no longer a one-line "Resumed
+  Claude chat" note. Picking it from the composer opens the whole conversation
+  in Open Run — prompts, reasoning, tool calls and their results, token counts —
+  rendered the same way a run Open Run executed itself is.
+- Opening one costs nothing. Adopting a chat imports its transcript and stops
+  there, instead of firing a `continue` prompt at the model just to have
+  something to show; the first turn Open Run runs is the message you type next.
+- Whether the history loads no longer depends on where the conversation goes
+  next. Reading a saved chat is separate from resuming one, so the transcript is
+  there whether you continue on the same CLI or hand the work to another runtime.
+  Runtimes without a transcript reader (Codex, Grok, Antigravity) resume exactly
+  as before.

--- a/src/fns/index.ts
+++ b/src/fns/index.ts
@@ -269,6 +269,20 @@ export const startChat = createServerFn({ method: 'POST' })
   )
   .handler(async ({ data }) => (await core()).startChat(data))
 
+export const openNativeChat = createServerFn({ method: 'POST' })
+  .validator(
+    (d: {
+      workspaceId: string
+      runtimeId: string
+      sessionId: string
+      sessionLabel?: string
+      model?: string
+      effort?: string
+      runtimeMode?: string
+    }) => d,
+  )
+  .handler(async ({ data }) => (await core()).openNativeChat(data))
+
 // --- Conversation ----------------------------------------------------------
 
 export const getConversation = createServerFn({ method: 'GET' })

--- a/src/lib/nativeSessions.ts
+++ b/src/lib/nativeSessions.ts
@@ -169,7 +169,7 @@ function numberField(obj: Record<string, unknown>, key: string): number | undefi
   return typeof value === 'number' && Number.isFinite(value) ? value : undefined
 }
 
-function parseIsoMs(value: string): number | undefined {
+export function parseIsoMs(value: string): number | undefined {
   if (!value.trim()) return undefined
   const ms = Date.parse(value)
   if (Number.isFinite(ms)) return ms
@@ -217,7 +217,8 @@ export function parseClaudeSessionsIndex(json: unknown): NativeSession[] {
   return out.sort((a, b) => b.modifiedAt - a.modifiedAt)
 }
 
-function userTextFromContent(content: unknown): string {
+/** Plain text out of an Anthropic user message (string or content blocks). */
+export function userTextFromContent(content: unknown): string {
   if (typeof content === 'string') return content
   if (!Array.isArray(content)) return ''
   const parts: string[] = []
@@ -229,7 +230,8 @@ function userTextFromContent(content: unknown): string {
   return parts.join('\n')
 }
 
-function isSkippableUserText(text: string): boolean {
+/** Slash-command echoes and IDE chatter that the CLI stores but never showed. */
+export function isSkippableUserText(text: string): boolean {
   const trimmed = text.trim()
   if (!trimmed) return true
   if (trimmed.startsWith('<command-name>') || trimmed.startsWith('<local-command')) return true

--- a/src/lib/nativeTranscript.ts
+++ b/src/lib/nativeTranscript.ts
@@ -1,0 +1,153 @@
+/**
+ * Native CLI transcript → chat turns. Parse-only, browser-safe.
+ *
+ * `nativeSessions.ts` reads each store's *index* for the picker; this module
+ * reads the body, so adopting a saved chat can render the whole conversation in
+ * Open Run instead of a one-line "resumed" note. The server half locates the
+ * files.
+ *
+ * Reading a transcript is independent of resuming one: a session id only loads
+ * back into the CLI that wrote it, but its text renders anywhere.
+ *
+ * Claude's session JSONL carries the same envelopes its `stream-json` stdout
+ * does, so `agentEvents/claude.ts` does the parsing here too — only turn
+ * segmentation and the TUI-only line types are new.
+ */
+import { parseClaudeObject } from './agentEvents/claude.ts'
+import type { ParsedTurnEvent } from './agentEvents/types.ts'
+import {
+  isSkippableUserText,
+  parseIsoMs,
+  userTextFromContent,
+  type NativeSessionKind,
+} from './nativeSessions.ts'
+import { mergeTurnUsage, type TurnUsage } from './turnUsage.ts'
+
+/** CLIs whose saved chats we can render. The rest still resume, without history. */
+export const TRANSCRIPT_IMPORT_KINDS = ['claude'] as const
+
+/** Keep an adopted chat from dwarfing the run it lands in; oldest turns go first. */
+export const MAX_IMPORT_TURNS = 200
+export const MAX_IMPORT_EVENTS = 4_000
+
+export type TranscriptTurn = {
+  /** User text that opened the turn; empty when the file starts mid-turn. */
+  prompt: string
+  promptAt: number
+  events: ParsedTurnEvent[]
+  /** Token counts the CLI reported, folded onto the assistant message. */
+  usage: TurnUsage | null
+  endedAt: number
+}
+
+export function supportsTranscriptImport(kind: string): kind is NativeSessionKind {
+  return (TRANSCRIPT_IMPORT_KINDS as readonly string[]).includes(kind)
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null
+}
+
+/**
+ * `~/.claude/projects/<cwd>/<sessionId>.jsonl` → one turn per user prompt.
+ *
+ * Lines are Anthropic envelopes (`type: user | assistant`) mixed with TUI
+ * bookkeeping (`ai-title`, `mode`, `attachment`, …) that has no chat meaning.
+ * A `user` line is either a real prompt — which opens a turn — or the
+ * `tool_result` half of the previous assistant message.
+ */
+export function parseClaudeTranscript(text: string): TranscriptTurn[] {
+  const turns: TranscriptTurn[] = []
+  let current: TranscriptTurn | null = null
+
+  const open = (prompt: string, at: number): TranscriptTurn => {
+    const turn: TranscriptTurn = { prompt, promptAt: at, events: [], usage: null, endedAt: at }
+    turns.push(turn)
+    return turn
+  }
+
+  for (const line of text.split('\n')) {
+    const trimmed = line.trim()
+    if (!trimmed) continue
+    let parsed: unknown
+    try {
+      parsed = JSON.parse(trimmed)
+    } catch {
+      continue
+    }
+    const rec = asRecord(parsed)
+    if (!rec) continue
+    // A sub-agent's transcript belongs to the tool call that spawned it.
+    if (rec.isSidechain === true) continue
+    const type = rec.type
+    if (type !== 'user' && type !== 'assistant') continue
+
+    const stamp = typeof rec.timestamp === 'string' ? rec.timestamp : ''
+    const at = parseIsoMs(stamp) ?? current?.endedAt ?? 0
+
+    if (type === 'user') {
+      const results = parseClaudeObject(rec)
+      if (results.length > 0) {
+        if (current) {
+          current.events.push(...results)
+          current.endedAt = at
+        }
+        continue
+      }
+      if (rec.isMeta === true) continue
+      const message = asRecord(rec.message)
+      const prompt = userTextFromContent(message?.content ?? rec.content)
+      if (isSkippableUserText(prompt)) continue
+      current = open(prompt, at)
+      continue
+    }
+
+    const events = parseClaudeObject(rec)
+    if (events.length === 0) continue
+    if (!current) current = open('', at)
+    for (const event of events) {
+      if (event.kind === 'usage') {
+        if (event.payload.usage) current.usage = mergeTurnUsage(current.usage, event.payload.usage)
+        continue
+      }
+      current.events.push(event)
+    }
+    current.endedAt = at
+  }
+
+  // Claude writes no `result` line to the session file, so close each answered
+  // turn ourselves — chat treats a turn without one as still in flight.
+  for (const turn of turns) {
+    if (turn.events.length > 0) {
+      turn.events.push({ kind: 'turn_done', payload: { stopReason: 'end_turn' } })
+    }
+  }
+
+  return turns.filter((turn) => turn.prompt.length > 0 || turn.events.length > 0)
+}
+
+/** Drop the oldest turns until the transcript fits the import caps. */
+export function trimTranscript(
+  turns: readonly TranscriptTurn[],
+  limits?: { maxTurns?: number; maxEvents?: number },
+): { turns: TranscriptTurn[]; dropped: number } {
+  const maxTurns = limits?.maxTurns ?? MAX_IMPORT_TURNS
+  const maxEvents = limits?.maxEvents ?? MAX_IMPORT_EVENTS
+  const kept: TranscriptTurn[] = []
+  let events = 0
+  for (let i = turns.length - 1; i >= 0; i -= 1) {
+    const turn = turns[i]!
+    if (kept.length >= maxTurns) break
+    if (kept.length > 0 && events + turn.events.length > maxEvents) break
+    kept.unshift(turn)
+    events += turn.events.length
+  }
+  return { turns: kept, dropped: turns.length - kept.length }
+}
+
+/** System-message note for the turns that did not fit. */
+export function omittedTurnsNote(dropped: number): string {
+  return `${dropped} earlier turn${dropped === 1 ? '' : 's'} not shown — open the chat in the CLI for the full history.`
+}

--- a/src/lib/queries.ts
+++ b/src/lib/queries.ts
@@ -938,6 +938,30 @@ export function attachmentUploader(workspaceId: string | undefined) {
   }
 }
 
+export function useOpenNativeChat() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (data: {
+      workspaceId: string
+      runtimeId: string
+      sessionId: string
+      sessionLabel?: string
+      model?: string
+      effort?: string
+      runtimeMode?: string
+    }) => fns.openNativeChat({ data }),
+    onSuccess: async (data) => {
+      qc.invalidateQueries({ queryKey: ['runs'] })
+      qc.invalidateQueries({ queryKey: ['workspaces'] })
+      qc.invalidateQueries({ queryKey: ['dashboard'] })
+      const runId = data?.runId
+      if (runId) {
+        await prefetchConversation(qc, runId)
+      }
+    },
+  })
+}
+
 export function useStartChat() {
   const qc = useQueryClient()
   return useMutation({

--- a/src/routes/runs.new.tsx
+++ b/src/routes/runs.new.tsx
@@ -26,11 +26,17 @@ import {
 } from '../lib/models'
 import { pickDefaultRuntime, visibleRuntimes } from '../lib/pickRuntime'
 import { pickerPrefForRuntime, usePickerPrefs } from '../lib/pickerPrefs'
-import { nativeResumeKindFor } from '../lib/nativeSessions'
+import {
+  nativeResumeKindFor,
+  type NativeSession,
+  type NativeSessionGroup,
+} from '../lib/nativeSessions'
+import { supportsTranscriptImport } from '../lib/nativeTranscript'
 import {
   attachmentUploader,
   useNativeSessions,
   useCreateWorkspace,
+  useOpenNativeChat,
   useProjectBranches,
   useProjects,
   useRuntimes,
@@ -72,6 +78,7 @@ function NewRun() {
   const { data: projects } = useProjects()
   const { data: runtimes } = useRuntimes()
   const startChat = useStartChat()
+  const openNativeChat = useOpenNativeChat()
   const createWorkspace = useCreateWorkspace()
 
   const [projectId, setProjectId] = useState(search.projectId ?? '')
@@ -235,6 +242,40 @@ function NewRun() {
     }
   }
 
+  /**
+   * Picking a saved chat opens it as its own run: the transcript is imported
+   * and shown, and nothing is prompted until the composer there is used. CLIs
+   * we cannot read a transcript for keep the old behaviour — the chat is armed
+   * here and adopted by the first message.
+   */
+  const pickNativeSession = (session: NativeSession, group: NativeSessionGroup) => {
+    setRuntimeId(group.runtimeId)
+    remember({ runtimeId: group.runtimeId })
+    if (!readyWorkspaceId || !supportsTranscriptImport(group.kind)) {
+      setResumeSessionId(session.sessionId)
+      setResumeSessionLabel(session.title)
+      return
+    }
+    setError(null)
+    // The composer's model belongs to the runtime it was picked for; a chat from
+    // another CLI takes that runtime's defaults instead.
+    const sameRuntime = group.runtimeId === runtimeId
+    openNativeChat.mutate(
+      {
+        workspaceId: readyWorkspaceId,
+        runtimeId: group.runtimeId,
+        sessionId: session.sessionId,
+        sessionLabel: session.title,
+        ...(sameRuntime ? { model, effort } : {}),
+        runtimeMode,
+      },
+      {
+        onSuccess: ({ runId }) => navigate({ to: '/runs/$runId', params: { runId } }),
+        onError: (err) => setError(err instanceof Error ? err.message : String(err)),
+      },
+    )
+  }
+
   const send = (prompt: string) => {
     if (!workspace || !runtime || sent) return
     setError(null)
@@ -306,18 +347,13 @@ function NewRun() {
                 selectedId={resumeSessionId}
                 selectedLabel={resumeSessionLabel}
                 onOpen={() => nativeQuery.refetch()}
-                disabled={!workspaceId || startChat.isPending}
+                disabled={!workspaceId || startChat.isPending || openNativeChat.isPending}
                 disabledReason="Pick a branch first"
                 onSelectNew={() => {
                   setResumeSessionId('')
                   setResumeSessionLabel('')
                 }}
-                onSelect={(session, group) => {
-                  setRuntimeId(group.runtimeId)
-                  setResumeSessionId(session.sessionId)
-                  setResumeSessionLabel(session.title)
-                  remember({ runtimeId: group.runtimeId })
-                }}
+                onSelect={pickNativeSession}
               />
             </>
           ) : null}

--- a/src/server/core.ts
+++ b/src/server/core.ts
@@ -47,6 +47,7 @@ import {
   type TaskRow,
 } from './db'
 import {
+  adoptNativeChat as _adoptNativeChat,
   answerApproval as _answerApproval,
   cancelRun as _cancelRun,
   cancelRunsForTask,
@@ -1091,6 +1092,42 @@ export function startChat(input: {
     runtimeMode: input.runtimeMode,
     resumeSessionId: input.resumeSessionId,
     resumeSessionLabel: input.resumeSessionLabel,
+  })
+  return { runId }
+}
+
+/**
+ * Open a saved CLI chat as a run — history only, no turn executed.
+ *
+ * The composer in the run that comes back is what starts the first real turn,
+ * so browsing an old conversation never costs a model call.
+ */
+export function openNativeChat(input: {
+  workspaceId: string
+  runtimeId: string
+  sessionId: string
+  sessionLabel?: string
+  model?: string
+  effort?: string
+  runtimeMode?: string
+}): { runId: string } {
+  const workspace = getWorkspace(input.workspaceId)
+  if (!workspace) throw new Error('Workspace not found')
+  assertWorkspaceReady(workspace.status)
+
+  const runtime = getRuntime(input.runtimeId)
+  if (!runtime) throw new Error('Runtime not found')
+
+  const runId = _adoptNativeChat({
+    runtime,
+    taskName: `Chat · ${workspace.branch}`,
+    workspaceId: workspace.id,
+    cwd: '',
+    sessionId: input.sessionId,
+    sessionLabel: input.sessionLabel ?? '',
+    model: input.model,
+    effort: input.effort,
+    runtimeMode: input.runtimeMode,
   })
   return { runId }
 }

--- a/src/server/executor.ts
+++ b/src/server/executor.ts
@@ -65,11 +65,11 @@ import { cachedModelsForBin } from './modelCatalog.ts'
 import { detectGhFailure } from '../lib/ghOutcome'
 import { assertRuntimeOnPath } from './runtimePath'
 import { nativeSessionExists } from './nativeSessions'
+import { importNativeTranscript } from './nativeImport'
 import {
   missingNativeSessionMessage,
   nativeResumeKindFor,
   nativeResumeNotSupportedMessage,
-  resumedNativeChatStub,
 } from '../lib/nativeSessions.ts'
 import { checksForWorkspace, clearCheckPass, runCheckPass } from './checks'
 import {
@@ -375,17 +375,17 @@ export function startRun(input: StartRunInput): string {
     db.prepare('UPDATE tasks SET lastRunAt = ? WHERE id = ?').run(now, input.taskId)
   }
 
+  // Adopting a chat brings its history with it where we can read the CLI's
+  // session file; where we cannot, this is still just the provenance note.
   if (resumeSessionId) {
-    db.prepare(
-      `INSERT INTO messages (id, runId, role, content, stdout, stderr, status, exitCode, diffSummary, createdAt, finishedAt)
-       VALUES (?, ?, 'system', ?, '', '', 'success', NULL, '', ?, ?)`,
-    ).run(
-      randomId('msg'),
+    importNativeTranscript({
       runId,
-      resumedNativeChatStub(resumeKind ?? 'claude', input.resumeSessionLabel ?? ''),
-      now - 1,
-      now - 1,
-    )
+      cwd,
+      kind: resumeKind ?? 'claude',
+      sessionId: resumeSessionId,
+      label: input.resumeSessionLabel ?? '',
+      before: now,
+    })
   }
 
   publishActivityLive({ type: 'run_changed', runId, status: 'running' })
@@ -401,6 +401,84 @@ export function startRun(input: StartRunInput): string {
     unattended: true,
     ...(input.source ? { source: input.source } : {}),
   })
+  return runId
+}
+
+/**
+ * Adopt a saved CLI chat as a run without prompting anything.
+ *
+ * The point is to read: the transcript lands in a finished run so the whole
+ * conversation is browsable in Open Run, and the composer's next message is the
+ * first turn Open Run actually executes (resumed on the same CLI, or handed off
+ * to another one). Runtimes with no transcript reader still get a run — with
+ * the provenance note alone — because resuming them works regardless.
+ */
+export function adoptNativeChat(input: {
+  runtime: RuntimeRow
+  taskName: string
+  workspaceId: string
+  cwd: string
+  sessionId: string
+  sessionLabel: string
+  model?: string
+  effort?: string
+  runtimeMode?: RuntimeMode | string
+}): string {
+  const db = getDb()
+  const runId = randomId('run')
+  const now = Date.now()
+
+  // No child process runs here, so the workspace is read, not locked.
+  const cwd =
+    input.workspaceId.trim().length > 0
+      ? resolveWorkspacePath(input.workspaceId)
+      : input.cwd && input.cwd.trim().length > 0
+        ? input.cwd
+        : process.cwd()
+
+  const sessionId = input.sessionId.trim()
+  const kind = nativeResumeKindFor(input.runtime)
+  if (!sessionId) throw new Error('Pick a saved chat to open')
+  if (!kind) throw new Error(nativeResumeNotSupportedMessage())
+  if (!nativeSessionExists(cwd, kind, sessionId)) {
+    throw new Error(missingNativeSessionMessage(kind))
+  }
+
+  const runtimeMode = parseRuntimeMode(input.runtimeMode ?? DEFAULT_RUNTIME_MODE)
+  db.prepare(
+    `INSERT INTO runs (id, taskId, taskName, runtimeId, trigger, status, command, cwd, workspaceId, pid, exitCode, stdout, stderr, startedAt, finishedAt, sessionId, baseBranch, baseSnapshot, model, effort, runtimeMode)
+     VALUES (@id, NULL, @taskName, @runtimeId, 'chat', 'success', @command, @cwd, @workspaceId, NULL, 0, '', '', @startedAt, @finishedAt, @sessionId, @baseBranch, @baseSnapshot, @model, @effort, @runtimeMode)`,
+  ).run({
+    id: runId,
+    taskName: input.taskName,
+    runtimeId: input.runtime.id,
+    // Nothing was executed here; the first real command line lands on the
+    // follow-up turn, and the log drawer hides an empty one.
+    command: '',
+    cwd,
+    workspaceId: input.workspaceId ?? '',
+    startedAt: now,
+    finishedAt: now,
+    sessionId,
+    baseBranch: currentBranch(cwd),
+    // The diff a follow-up shows starts here, not at whatever the CLI did.
+    baseSnapshot: captureBaseSnapshot(cwd),
+    model: input.model?.trim() ?? '',
+    effort: input.effort?.trim() ?? '',
+    runtimeMode,
+  })
+
+  const imported = importNativeTranscript({
+    runId,
+    cwd,
+    kind,
+    sessionId,
+    label: input.sessionLabel,
+    before: now,
+  })
+  db.prepare('UPDATE runs SET startedAt = ? WHERE id = ?').run(imported.startedAt, runId)
+
+  publishActivityLive({ type: 'run_changed', runId, status: 'success' })
   return runId
 }
 

--- a/src/server/nativeImport.ts
+++ b/src/server/nativeImport.ts
@@ -1,0 +1,131 @@
+/**
+ * Write an adopted CLI chat into a run's transcript.
+ *
+ * The rows are the ordinary ones — a `messages` pair per turn plus its
+ * `turn_events` — so chat renders an imported conversation exactly like one Open
+ * Run executed itself, and a later follow-up simply appends to it.
+ *
+ * Nothing here spawns anything: importing is a read of the CLI's own session
+ * file, independent of whether that session can still be resumed.
+ */
+import { getDb } from './db'
+import { readNativeTranscript } from './nativeTranscript'
+import { resumedNativeChatStub, type NativeSessionKind } from '../lib/nativeSessions.ts'
+import { omittedTurnsNote, trimTranscript } from '../lib/nativeTranscript.ts'
+
+function newId(prefix: string): string {
+  return `${prefix}_${Date.now().toString(36)}${Math.random().toString(36).slice(2, 8)}`
+}
+
+export type NativeImportResult = {
+  /** Turns actually written; 0 means only the "resumed" note landed. */
+  turns: number
+  /** Timestamp of the oldest imported message, for the run's startedAt. */
+  startedAt: number
+}
+
+/**
+ * Import `sessionId`'s transcript into `runId`, newest turns first if it does
+ * not all fit. Always writes the provenance note, so a runtime with no reader
+ * (or a transcript we could not parse) behaves as it did before.
+ *
+ * `before` is the timestamp the caller's own next row will use — everything
+ * written here sorts strictly ahead of it.
+ */
+export function importNativeTranscript(input: {
+  runId: string
+  cwd: string
+  kind: NativeSessionKind
+  sessionId: string
+  label: string
+  before: number
+}): NativeImportResult {
+  const { turns, dropped } = trimTranscript(
+    readNativeTranscript(input.cwd, input.kind, input.sessionId),
+  )
+
+  const db = getDb()
+  const insertMessage = db.prepare(
+    `INSERT INTO messages (id, runId, role, content, stdout, stderr, status, exitCode, diffSummary, usage, sourceProvider, sourceUrl, sourceLabel, createdAt, finishedAt)
+     VALUES (@id, @runId, @role, @content, '', '', @status, NULL, '', @usage, '', '', '', @createdAt, @finishedAt)`,
+  )
+  const insertEvent = db.prepare(
+    `INSERT INTO turn_events (id, messageId, runId, seq, kind, payload, createdAt)
+     VALUES (@id, @messageId, @runId, @seq, @kind, @payload, @createdAt)`,
+  )
+
+  const first = turns[0]?.promptAt ?? 0
+  const limit = input.before - 1
+  // Source timestamps, kept strictly increasing so `ORDER BY createdAt` cannot
+  // interleave a turn, and capped so the caller's next row still comes last.
+  let clock = (first > 0 ? first : input.before) - 2
+  const at = (ms: number): number => {
+    const wanted = Number.isFinite(ms) && ms > 0 ? ms : 0
+    clock = Math.min(Math.max(clock + 1, wanted), limit)
+    return clock
+  }
+
+  const note = (text: string) => {
+    const createdAt = at(0)
+    insertMessage.run({
+      id: newId('msg'),
+      runId: input.runId,
+      role: 'system',
+      content: text,
+      status: 'success',
+      usage: '',
+      createdAt,
+      finishedAt: createdAt,
+    })
+  }
+
+  const write = db.transaction(() => {
+    note(resumedNativeChatStub(input.kind, input.label))
+    if (dropped > 0) note(omittedTurnsNote(dropped))
+
+    for (const turn of turns) {
+      if (turn.prompt) {
+        const createdAt = at(turn.promptAt)
+        insertMessage.run({
+          id: newId('msg'),
+          runId: input.runId,
+          role: 'user',
+          content: turn.prompt,
+          status: 'success',
+          usage: '',
+          createdAt,
+          finishedAt: createdAt,
+        })
+      }
+      if (turn.events.length === 0) continue
+
+      const messageId = newId('msg')
+      const createdAt = at(turn.endedAt)
+      insertMessage.run({
+        id: messageId,
+        runId: input.runId,
+        role: 'assistant',
+        // Chat reads assistant text back out of the events, as it does live.
+        content: '',
+        status: 'success',
+        usage: turn.usage ? JSON.stringify(turn.usage) : '',
+        createdAt,
+        finishedAt: createdAt,
+      })
+      turn.events.forEach((event, seq) => {
+        insertEvent.run({
+          id: newId('ev'),
+          messageId,
+          runId: input.runId,
+          seq,
+          kind: event.kind,
+          payload: JSON.stringify(event.payload),
+          createdAt,
+        })
+      })
+    }
+  })
+  write()
+
+  return { turns: turns.length, startedAt: first > 0 ? first : input.before }
+}

--- a/src/server/nativeSessions.ts
+++ b/src/server/nativeSessions.ts
@@ -119,6 +119,12 @@ function listClaudeFromJsonl(dir: string): NativeSession[] {
   return out
 }
 
+/** Where one Claude chat's JSONL lives, whether or not it exists. */
+export function claudeSessionFile(cwd: string, sessionId: string): string {
+  const dir = claudeDir(cwd)
+  return dir ? join(dir, `${sessionId}.jsonl`) : ''
+}
+
 const claudeAdapter: NativeSessionAdapter = {
   list(cwd) {
     const trimmed = cwd.trim()
@@ -130,7 +136,7 @@ const claudeAdapter: NativeSessionAdapter = {
   exists(cwd, sessionId) {
     const id = sessionId.trim()
     if (!id || !cwd.trim()) return false
-    const file = join(claudeDir(cwd), `${id}.jsonl`)
+    const file = claudeSessionFile(cwd, id)
     try {
       return statSync(file).isFile()
     } catch {

--- a/src/server/nativeTranscript.ts
+++ b/src/server/nativeTranscript.ts
@@ -1,0 +1,32 @@
+/**
+ * Read one saved CLI chat off disk, in full.
+ *
+ * The parsing lives in `lib/nativeTranscript.ts` (pure, testable); this module
+ * only locates the file. Kinds without a reader return no turns, and the caller
+ * falls back to the one-line "resumed" note.
+ */
+import { existsSync, readFileSync } from 'node:fs'
+import type { NativeSessionKind } from '../lib/nativeSessions.ts'
+import {
+  parseClaudeTranscript,
+  supportsTranscriptImport,
+  type TranscriptTurn,
+} from '../lib/nativeTranscript.ts'
+import { claudeSessionFile } from './nativeSessions.ts'
+
+export function readNativeTranscript(
+  cwd: string,
+  kind: NativeSessionKind,
+  sessionId: string,
+): TranscriptTurn[] {
+  const id = sessionId.trim()
+  if (!id || !cwd.trim() || !supportsTranscriptImport(kind)) return []
+  const file = claudeSessionFile(cwd, id)
+  if (!file || !existsSync(file)) return []
+  try {
+    return parseClaudeTranscript(readFileSync(file, 'utf8'))
+  } catch {
+    // An unreadable or half-written transcript is not worth failing a run over.
+    return []
+  }
+}


### PR DESCRIPTION
Adopting a chat started in Claude Code itself showed a single `Resumed Claude chat · <title>` line, then fired a `continue` prompt at the model so the run had something to display.

Reading a transcript and resuming a session are independent concerns: a session id only loads back into the CLI that wrote it, but its text renders anywhere. So the history is now read off disk and written as ordinary `messages` + `turn_events` rows, and picking a chat executes nothing.

## What changed

- `lib/nativeTranscript.ts` — pure parser. Claude's session JSONL carries the same envelopes its `stream-json` stdout does, so `lib/agentEvents/claude.ts` does the work; only turn segmentation (a `user` line is either a prompt or the `tool_result` half of the previous answer) and the TUI-only line types (`ai-title`, `mode`, `attachment`, sidechains) are new. Caps at 200 turns / 4000 events, oldest dropped, with a note for what was left out.
- `server/nativeTranscript.ts` — locates the file. Kinds without a reader return no turns.
- `server/nativeImport.ts` — writes the turns into a run, source timestamps kept strictly increasing and capped so the caller's next row still sorts last.
- `executor.adoptNativeChat` + `core.openNativeChat` — create a finished run holding only the imported chat. The composer there starts the first turn Open Run actually executes.
- `startRun` keeps working for automations and the prompt-first path: a resumed chat now brings its history instead of the one-line note.

## Scope

Claude only for now. Codex (rollout envelopes differ from `exec --json`), Grok (`chat_history.jsonl`) and Antigravity (per-conversation SQLite) fall back to today's behaviour — armed in the composer, adopted by the first message — until each gets a reader.

## Testing

Not run — validation is the maintainer's call. Worth eyeballing: a long Claude chat with sub-agents and MCP tools, then a follow-up on it (same runtime and after a switch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)