### PR TITLE
fix: restore typecheck and format on main

### DIFF
--- a/src/components/AddProjectModal.tsx
+++ b/src/components/AddProjectModal.tsx
@@ -29,8 +29,7 @@ export type AddedProject = {
 type Crumb = { name: string; path: string; home?: boolean }
 
 function crumbsFor(dir: string, home: string): Crumb[] {
-  const rest =
-    dir === home ? '' : dir.startsWith(`${home}/`) ? dir.slice(home.length + 1) : null
+  const rest = dir === home ? '' : dir.startsWith(`${home}/`) ? dir.slice(home.length + 1) : null
   const out: Crumb[] =
     rest === null ? [{ name: '/', path: '/' }] : [{ name: 'Home', path: home, home: true }]
   let acc = rest === null ? '' : home
@@ -182,29 +181,25 @@ export function AddProjectModal({
             />
           ) : (
             <div className="scroll-thin flex min-w-0 flex-1 items-center gap-0.5 overflow-x-auto rounded-md border border-border bg-[var(--bg-chrome)] px-1.5 py-1">
-              {current
-                ? crumbsFor(current.path, current.home).map((crumb, index) => (
-                    <span key={crumb.path} className="flex shrink-0 items-center">
-                      {index > 0 ? (
-                        <ChevronRight className="h-3 w-3 text-tier-quaternary" />
-                      ) : null}
-                      <button
-                        type="button"
-                        onClick={() => navigate(crumb.path)}
-                        className={`flex items-center gap-1 rounded px-1.5 py-0.5 text-[13px] transition-colors hover:bg-hover ${
-                          crumb.path === current.path
-                            ? 'text-foreground'
-                            : 'text-tier-secondary'
-                        }`}
-                      >
-                        {crumb.home ? <House className="h-3 w-3" /> : null}
-                        <span className="mono">{crumb.name}</span>
-                      </button>
-                    </span>
-                  ))
-                : (
-                    <span className="px-1 text-[13px] text-tier-quaternary">Loading…</span>
-                  )}
+              {current ? (
+                crumbsFor(current.path, current.home).map((crumb, index) => (
+                  <span key={crumb.path} className="flex shrink-0 items-center">
+                    {index > 0 ? <ChevronRight className="h-3 w-3 text-tier-quaternary" /> : null}
+                    <button
+                      type="button"
+                      onClick={() => navigate(crumb.path)}
+                      className={`flex items-center gap-1 rounded px-1.5 py-0.5 text-[13px] transition-colors hover:bg-hover ${
+                        crumb.path === current.path ? 'text-foreground' : 'text-tier-secondary'
+                      }`}
+                    >
+                      {crumb.home ? <House className="h-3 w-3" /> : null}
+                      <span className="mono">{crumb.name}</span>
+                    </button>
+                  </span>
+                ))
+              ) : (
+                <span className="px-1 text-[13px] text-tier-quaternary">Loading…</span>
+              )}
             </div>
           )}
 
@@ -410,7 +405,6 @@ export function AddProjectModal({
         {[listing.error, createFolder.error, add.error].map((error, index) =>
           error ? (
             <p
-              // biome-ignore lint/suspicious/noArrayIndexKey: fixed-length error slots
               key={index}
               className="rounded-md border border-border px-3 py-2 text-ui-base text-tier-secondary"
             >

--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -89,7 +89,11 @@ import {
   usePendingAttachments,
   type AttachmentUploader,
 } from './chat/index'
-import { attachmentPathsIn, promptWithAttachments, promptWithoutAttachments } from '../lib/attachments'
+import {
+  attachmentPathsIn,
+  promptWithAttachments,
+  promptWithoutAttachments,
+} from '../lib/attachments'
 import { activitySteps, latestActivity } from '../lib/turnActivity'
 import { verificationPhase } from '../lib/runPhase'
 import type { CachedCheckResult } from '../lib/applyRunLiveEvent'
@@ -935,10 +939,7 @@ export function Composer({
   }
 
   const canSend =
-    !blocked &&
-    !pending &&
-    !files.uploading &&
-    (value.trim().length > 0 || files.paths.length > 0)
+    !blocked && !pending && !files.uploading && (value.trim().length > 0 || files.paths.length > 0)
 
   return (
     <div className={`relative ${className ?? 'mx-auto w-full min-w-0 max-w-3xl pt-2 pl-2'}`}>
@@ -1119,14 +1120,8 @@ export function Composer({
                 type="button"
                 disabled={!canSend}
                 onClick={() => submit()}
-                aria-label={
-                  pending ? 'Sending' : running ? 'Queue message' : 'Send message'
-                }
-                title={
-                  running
-                    ? 'Queue this message (↵) · ⌘↵ interrupts and sends now'
-                    : undefined
-                }
+                aria-label={pending ? 'Sending' : running ? 'Queue message' : 'Send message'}
+                title={running ? 'Queue this message (↵) · ⌘↵ interrupts and sends now' : undefined}
                 className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-primary/90 text-primary-foreground transition-colors enabled:cursor-pointer enabled:hover:bg-primary disabled:pointer-events-none disabled:opacity-30"
               >
                 {pending ? (

--- a/src/components/chat/ComposerAttachments.tsx
+++ b/src/components/chat/ComposerAttachments.tsx
@@ -182,7 +182,11 @@ export function AttachmentStrip({
           className={`group relative h-16 w-16 overflow-hidden rounded-lg border ${
             row.error ? 'border-danger' : 'border-border'
           }`}
-          title={row.error ? `${row.name} — ${row.error}` : `${row.name} · ${formatAttachmentSize(row.size)}`}
+          title={
+            row.error
+              ? `${row.name} — ${row.error}`
+              : `${row.name} · ${formatAttachmentSize(row.size)}`
+          }
         >
           <img src={row.previewUrl} alt={row.name} className="h-full w-full object-cover" />
           {!row.path && !row.error ? (

--- a/src/components/chat/QueuedMessages.tsx
+++ b/src/components/chat/QueuedMessages.tsx
@@ -64,9 +64,7 @@ export function QueuedMessages({
             onClick={onSendNow}
             disabled={busy}
             title={
-              running
-                ? 'Interrupt the agent and send these now'
-                : 'Send the queued messages now'
+              running ? 'Interrupt the agent and send these now' : 'Send the queued messages now'
             }
             className="h-6 rounded-md border border-border bg-secondary/80 px-2 text-[12px] font-medium text-foreground transition-colors hover:bg-secondary disabled:cursor-not-allowed disabled:opacity-40"
           >

--- a/src/lib/attachments.ts
+++ b/src/lib/attachments.ts
@@ -17,12 +17,7 @@ export const MAX_ATTACHMENT_BYTES = 8 * 1024 * 1024
 
 export const MAX_ATTACHMENTS_PER_MESSAGE = 5
 
-export const ACCEPTED_IMAGE_TYPES = [
-  'image/png',
-  'image/jpeg',
-  'image/webp',
-  'image/gif',
-] as const
+export const ACCEPTED_IMAGE_TYPES = ['image/png', 'image/jpeg', 'image/webp', 'image/gif'] as const
 
 const EXTENSIONS: Record<string, string> = {
   'image/png': 'png',

--- a/src/lib/demoConversation.ts
+++ b/src/lib/demoConversation.ts
@@ -356,8 +356,10 @@ export function demoConversation(runId: string, now: number = Date.now()) {
     },
     messages: messages(runId, t0, t1),
     checkResults: [],
+    queued: [],
     verdict: 'unverified' as const,
     canFollowUp: false,
+    canQueueFollowUp: false,
     canSwitchRuntime: false,
     workspace: {
       id: WS_ID,

--- a/src/lib/demoConversation.ts
+++ b/src/lib/demoConversation.ts
@@ -353,6 +353,7 @@ export function demoConversation(runId: string, now: number = Date.now()) {
       verdict: 'unverified',
       repairAttempts: 0,
       timedOut: 0,
+      lastReadAt: t1,
     },
     messages: messages(runId, t0, t1),
     checkResults: [],

--- a/src/routes/runs.new.tsx
+++ b/src/routes/runs.new.tsx
@@ -175,7 +175,8 @@ function NewRun() {
   }, [models, runtimeId])
 
   const workspace = workspaces.find((w) => w.id === workspaceId)
-  const readyWorkspaceId = workspace && isWorkspaceReady(workspace.status) ? workspace.id : undefined
+  const readyWorkspaceId =
+    workspace && isWorkspaceReady(workspace.status) ? workspace.id : undefined
   const uploadAttachment = useMemo(() => attachmentUploader(readyWorkspaceId), [readyWorkspaceId])
   const blockedReason = !projects?.length
     ? 'Add a project before starting a run.'

--- a/src/server/messageQueue.ts
+++ b/src/server/messageQueue.ts
@@ -25,9 +25,9 @@ export function listQueuedMessages(runId: string): QueuedMessage[] {
 
 export function queuedMessageDepth(runId: string): number {
   return (
-    getDb()
-      .prepare('SELECT COUNT(*) AS n FROM message_queue WHERE runId = ?')
-      .get(runId) as { n: number }
+    getDb().prepare('SELECT COUNT(*) AS n FROM message_queue WHERE runId = ?').get(runId) as {
+      n: number
+    }
   ).n
 }
 


### PR DESCRIPTION
Main has been red since `e555228`. Two unrelated causes.

**Typecheck (30 errors).** Three fields were added to the conversation payload over time and the demo overlay in `lib/demoConversation.ts` never followed:

| Field | Added by |
| --- | --- |
| `queued` | `feat(chat): queue follow-ups typed while the agent works` |
| `canQueueFollowUp` | same |
| `lastReadAt` (on `run`) | `feat(runs): mark runs unread until you open them` |

The `demo ? demoConversation(runId) : fns.getConversation(...)` union in `conversationQueryOptions` then failed to satisfy `FetchQueryOptions`, TypeScript widened the inferred data to `{}`, and ~28 `TS2339`/`TS7006` errors cascaded into `runs.$runId.tsx`. The route errors are all downstream — the fixture is the only real defect.

**Biome.** Seven unformatted files, plus a `noArrayIndexKey` suppression in `AddProjectModal.tsx` that Biome no longer needs and warned about. `biome check --write src scripts` — every hunk is line-width reflow, no semantic change.

`tsc --noEmit` is clean locally on TypeScript 7.0.2, matching the lockfile and CI.

**Worth a follow-up:** the demo run object is the last `RunRow` literal outside the DB layer, so it silently drifts every time the row grows. Annotating `demoConversation` with the real payload type would make the next drift fail at the fixture with one precise error instead of ~30 cascading ones in a route.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QskvM5oSsyMvPyLMDceaQk