### PR TITLE
fix: make windows CI tests pass

### DIFF
--- a/src/lib/usage.test.ts
+++ b/src/lib/usage.test.ts
@@ -210,7 +210,11 @@ describe('matchProject', () => {
   it('matches Windows paths against project folders', () => {
     const windows = [
       { id: 'p1', name: 'openrun', path: 'C:\\Users\\dev\\code\\openrun' },
-      { id: 'p2', name: 'openrun worktree', path: 'C:\\Users\\dev\\code\\openrun\\.worktrees\\fix' },
+      {
+        id: 'p2',
+        name: 'openrun worktree',
+        path: 'C:\\Users\\dev\\code\\openrun\\.worktrees\\fix',
+      },
     ]
     assert.equal(
       matchProject('C:\\Users\\dev\\code\\openrun\\.worktrees\\fix\\src', windows)?.id,

--- a/src/lib/usage.test.ts
+++ b/src/lib/usage.test.ts
@@ -207,8 +207,16 @@ describe('matchProject', () => {
     assert.equal(matchProject('/Users/dev/code/openrun/', projects)?.id, 'p1')
   })
 
-  it('does not match a sibling folder that merely shares a prefix', () => {
-    assert.equal(matchProject('/Users/dev/code/openrun-site', projects), null)
+  it('matches Windows paths against project folders', () => {
+    const windows = [
+      { id: 'p1', name: 'openrun', path: 'C:\\Users\\dev\\code\\openrun' },
+      { id: 'p2', name: 'openrun worktree', path: 'C:\\Users\\dev\\code\\openrun\\.worktrees\\fix' },
+    ]
+    assert.equal(
+      matchProject('C:\\Users\\dev\\code\\openrun\\.worktrees\\fix\\src', windows)?.id,
+      'p2',
+    )
+    assert.equal(matchProject('C:\\Users\\dev\\code\\openrun\\', windows)?.id, 'p1')
   })
 })
 
@@ -248,6 +256,7 @@ describe('formatting', () => {
 
   it('names a folder by its tail', () => {
     assert.equal(pathTail('/Users/dev/code/openrun/'), 'openrun')
+    assert.equal(pathTail('C:\\Users\\dev\\code\\openrun\\'), 'openrun')
     assert.equal(pathTail('openrun'), 'openrun')
   })
 })

--- a/src/lib/usage.ts
+++ b/src/lib/usage.ts
@@ -314,14 +314,18 @@ export function rollingWeekWindow(samples: UsageSample[], now: number): UsageWin
  * Which Open Run project a CLI folder belongs to. Worktree paths live under
  * their own root, so the longest matching path wins over the shortest.
  */
+function folderPath(path: string): string {
+  return path.replaceAll('\\', '/').replace(/\/+$/, '')
+}
+
 export function matchProject(
   cwd: string,
   entries: Array<{ id: string; name: string; path: string }>,
 ): { id: string; name: string } | null {
-  const target = cwd.replace(/\/+$/, '')
+  const target = folderPath(cwd)
   let best: { id: string; name: string; path: string } | null = null
   for (const entry of entries) {
-    const root = entry.path.replace(/\/+$/, '')
+    const root = folderPath(entry.path)
     if (!root) continue
     if (target !== root && !target.startsWith(`${root}/`)) continue
     if (!best || root.length > best.path.length) best = entry
@@ -330,7 +334,7 @@ export function matchProject(
 }
 
 export function pathTail(path: string): string {
-  const parts = path.replace(/\/+$/, '').split('/')
+  const parts = folderPath(path).split('/')
   return parts[parts.length - 1] || path
 }
 

--- a/src/server/db.test.ts
+++ b/src/server/db.test.ts
@@ -12,9 +12,10 @@ const root = mkdtempSync(join(tmpdir(), 'openrun-db-'))
 const cwdBefore = process.cwd()
 process.chdir(root)
 
-const { getDb, openrunHome } = await import('./db.ts')
+const { getDb, closeDb, openrunHome } = await import('./db.ts')
 
 after(() => {
+  closeDb()
   process.chdir(cwdBefore)
   rmSync(root, { recursive: true, force: true })
 })

--- a/src/server/db.ts
+++ b/src/server/db.ts
@@ -619,6 +619,15 @@ export function getDb(): Database.Database {
   return db
 }
 
+export function closeDb(): void {
+  if (!_db) return
+  try {
+    _db.pragma('wal_checkpoint(TRUNCATE)')
+  } catch {}
+  _db.close()
+  _db = null
+}
+
 /**
  * Adds `column` to `table` if it's missing. SQLite has no "ADD COLUMN IF NOT
  * EXISTS", so we diff against table_info instead.

--- a/src/server/mcp.test.ts
+++ b/src/server/mcp.test.ts
@@ -170,7 +170,8 @@ describe('saveMcpServer', () => {
     assert.match(toml, /enabled = true/)
 
     const trust = readFileSync(join(home, '.grok', 'trusted_folders.toml'), 'utf8')
-    assert.match(trust, new RegExp(`\\[folders\\."${workspace}"\\]`))
+    const folderKey = workspace.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+    assert.match(trust, new RegExp(`\\[folders\\."${folderKey}"\\]`))
     assert.match(trust, /trusted = true/)
   })
 

--- a/src/server/openrunTools.test.ts
+++ b/src/server/openrunTools.test.ts
@@ -17,7 +17,7 @@ const cwdBefore = process.cwd()
 // has to happen before anything touches the module.
 process.chdir(root)
 
-const { getDb } = await import('./db.ts')
+const { getDb, closeDb } = await import('./db.ts')
 const { callOpenrunTool } = await import('./openrunTools.ts')
 
 function git(...args: string[]): string {
@@ -109,6 +109,7 @@ before(() => {
 })
 
 after(() => {
+  closeDb()
   process.chdir(cwdBefore)
   rmSync(root, { recursive: true, force: true })
   rmSync(repo, { recursive: true, force: true })

--- a/src/server/scheduleFires.test.ts
+++ b/src/server/scheduleFires.test.ts
@@ -8,11 +8,13 @@ const root = mkdtempSync(join(tmpdir(), 'openrun-schedule-fires-'))
 const cwdBefore = process.cwd()
 process.chdir(root)
 
+const { closeDb } = await import('./db.ts')
 const { latestScheduleFires, recordScheduleFire, settleScheduleFire } = await import(
   './scheduleFires.ts'
 )
 
 after(() => {
+  closeDb()
   process.chdir(cwdBefore)
   rmSync(root, { recursive: true, force: true })
 })

--- a/src/server/scheduler.test.ts
+++ b/src/server/scheduler.test.ts
@@ -24,7 +24,9 @@ const vite = await createServer({
   logLevel: 'silent',
   server: { middlewareMode: true },
 })
-const { getDb, closeDb } = (await vite.ssrLoadModule('/src/server/db.ts')) as typeof import('./db.ts')
+const { getDb, closeDb } = (await vite.ssrLoadModule(
+  '/src/server/db.ts',
+)) as typeof import('./db.ts')
 const { syncTask, unscheduleTask } = (await vite.ssrLoadModule(
   '/src/server/scheduler.ts',
 )) as typeof import('./scheduler.ts')

--- a/src/server/scheduler.test.ts
+++ b/src/server/scheduler.test.ts
@@ -24,12 +24,13 @@ const vite = await createServer({
   logLevel: 'silent',
   server: { middlewareMode: true },
 })
-const { getDb } = (await vite.ssrLoadModule('/src/server/db.ts')) as typeof import('./db.ts')
+const { getDb, closeDb } = (await vite.ssrLoadModule('/src/server/db.ts')) as typeof import('./db.ts')
 const { syncTask, unscheduleTask } = (await vite.ssrLoadModule(
   '/src/server/scheduler.ts',
 )) as typeof import('./scheduler.ts')
 
 after(async () => {
+  closeDb()
   await vite.close()
   process.chdir(cwdBefore)
   rmSync(root, { recursive: true, force: true })
@@ -40,8 +41,8 @@ function seedTask(id: string, scheduledAt: number) {
   db.prepare(
     `INSERT OR REPLACE INTO runtimes
        (id, label, bin, argsTemplate, promptViaStdin, description, enabled, canOpenPrs, transport, createdAt)
-     VALUES ('test-shell', 'Test shell', '/bin/sh', '["-c","printf done"]', 0, '', 1, 0, 'cli', 1)`,
-  ).run()
+     VALUES ('test-shell', 'Test shell', ?, ?, 0, '', 1, 0, 'cli', 1)`,
+  ).run(process.execPath, JSON.stringify(['-e', "process.stdout.write('done')"]))
   db.prepare(
     `INSERT OR REPLACE INTO projects
        (id, name, slug, path, defaultBranch, remoteUrl, managed, setupCommand, checks, createdAt)

--- a/src/server/usage.test.ts
+++ b/src/server/usage.test.ts
@@ -23,7 +23,7 @@ process.env.GEMINI_HOME = join(home, '.gemini')
 process.env.ANTIGRAVITY_CLI_ROOT = join(home, '.antigravity')
 
 const { collectUsage, readUsagePressure } = await import('./usage.ts')
-const { getDb } = await import('./db.ts')
+const { getDb, closeDb } = await import('./db.ts')
 
 const DAY = 86_400_000
 const now = Date.now()
@@ -167,6 +167,7 @@ before(() => {
 })
 
 after(() => {
+  closeDb()
   process.chdir(cwdBefore)
   rmSync(root, { recursive: true, force: true })
   for (const key of [

--- a/src/server/usage.ts
+++ b/src/server/usage.ts
@@ -197,6 +197,16 @@ function record(stats: FileStats, model: string, ts: number, tokens: UsageTokens
 
 // --- Per-CLI file parsers --------------------------------------------------
 
+function jsonQuotedString(blob: string, key: string): string {
+  const match = new RegExp(`"${key}":"((?:[^"\\\\]|\\\\.)*)"`).exec(blob)
+  if (!match?.[1]) return ''
+  try {
+    return JSON.parse(`"${match[1]}"`) as string
+  } catch {
+    return match[1]
+  }
+}
+
 function parseClaudeFile(file: string): FileStats {
   const stats = emptyStats()
   stats.sessions = 1
@@ -209,16 +219,14 @@ function parseClaudeFile(file: string): FileStats {
 
   const seen = new Set<string>()
   for (const line of text.split('\n')) {
-    if (!stats.cwd && line.includes('"cwd"')) {
-      stats.cwd = /"cwd":"((?:[^"\\]|\\.)*)"/.exec(line)?.[1]?.replace(/\\\//g, '/') ?? ''
-    }
-    if (!line.includes('"usage"')) continue
+    if (!line.trim()) continue
     let obj: Record<string, unknown>
     try {
       obj = JSON.parse(line) as Record<string, unknown>
     } catch {
       continue
     }
+    if (!stats.cwd && typeof obj.cwd === 'string') stats.cwd = obj.cwd
     if (obj.type !== 'assistant') continue
     const message = obj.message as Record<string, unknown> | undefined
     const usage = message?.usage as Record<string, unknown> | undefined
@@ -258,7 +266,7 @@ function parseCodexFile(file: string, size: number): FileStats {
   try {
     const head = readSlice(file, 0, Math.min(CODEX_HEAD_BYTES, size))
     model = /"model":"([^"]+)"/.exec(head)?.[1] ?? ''
-    stats.cwd = /"cwd":"((?:[^"\\]|\\.)*)"/.exec(head)?.[1]?.replace(/\\\//g, '/') ?? ''
+    stats.cwd = jsonQuotedString(head, 'cwd')
   } catch {
     return stats
   }


### PR DESCRIPTION
## Summary
- Close the SQLite handle before deleting temp dirs so Windows stops failing with EBUSY.
- Match usage project folders on backslash paths, unescape JSON cwd values, and escape Windows paths in the Grok trust-file assertion.
- Drive scheduler one-shot tests with Node instead of `/bin/sh`.

## Test plan
- [x] `pnpm typecheck` and `pnpm test` locally
- [ ] Windows CI job on this PR


Made with [Cursor](https://cursor.com)