### PR TITLE
build(deps): move pnpm overrides to the workspace root

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,11 +82,5 @@
     "@vitejs/plugin-react": "^6.0.5",
     "typescript": "^7.0.2",
     "vite": "^8.2.1"
-  },
-  "pnpm": {
-    "overrides": {
-      "js-yaml": ">=4.3.1",
-      "nanoid": ">=3.3.17"
-    }
   }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,3 +2,9 @@
 # here made pnpm run `node-gyp rebuild` anyway, which fails on GitHub's
 # windows-latest image (Visual Studio 2026 / node-gyp 11).
 onlyBuiltDependencies: []
+
+# Security floors for transitive deps. pnpm only honours overrides from the
+# workspace root, so the private tree repeats these in its own root file.
+overrides:
+  js-yaml: '>=4.3.1'
+  nanoid: '>=3.3.17'


### PR DESCRIPTION
pnpm reads `overrides` only from the workspace root, so the block in
package.json was inert for anyone installing from this repo.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01N8adAqM2UNmT1ZPCJQZfSe

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014irp7qsPXZVzvmYxqK4hqP