### PR TITLE
fix(dev): keep client aborts out of the dev server log

### DIFF
--- a/src/lib/clientAbort.ts
+++ b/src/lib/clientAbort.ts
@@ -1,0 +1,15 @@
+/** Codes Node/undici use when the peer hangs up mid-request. */
+const ABORT_CODES = new Set(['ECONNRESET', 'ECONNABORTED', 'ERR_STREAM_PREMATURE_CLOSE'])
+
+/** True when `error` (or anything it wraps) is a client that went away, not a real fault. */
+export function isClientAbort(error: unknown): boolean {
+  for (let e: unknown = error, depth = 0; e && depth < 5; depth++) {
+    if (e instanceof Error) {
+      if (e.name === 'AbortError') return true
+      const code = (e as NodeJS.ErrnoException).code
+      if (code && ABORT_CODES.has(code)) return true
+      e = e.cause
+    } else break
+  }
+  return false
+}

--- a/src/start.ts
+++ b/src/start.ts
@@ -5,23 +5,11 @@
  */
 import { createCsrfMiddleware, createMiddleware, createStart } from '@tanstack/react-start'
 
+import { isClientAbort } from './lib/clientAbort.ts'
+
 // Server functions are same-origin RPC, so a cross-site page must not drive them with ambient
 // credentials. API routes are exempt: the mobile surface carries its own bearer token.
 const csrfGuard = createCsrfMiddleware({ filter: (ctx) => ctx.handlerType === 'serverFn' })
-
-const ABORT_CODES = new Set(['ECONNRESET', 'ECONNABORTED', 'ERR_STREAM_PREMATURE_CLOSE'])
-
-function isClientAbort(error: unknown): boolean {
-  for (let e: unknown = error, depth = 0; e && depth < 5; depth++) {
-    if (e instanceof Error) {
-      if (e.name === 'AbortError') return true
-      const code = (e as NodeJS.ErrnoException).code
-      if (code && ABORT_CODES.has(code)) return true
-      e = e.cause
-    } else break
-  }
-  return false
-}
 
 // Reloading a page or closing an SSE tab tears the socket down mid-response.
 // Nothing is left to write to, but h3 still treats the abort as an unhandled

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,6 +6,7 @@ import { tanstackStart } from '@tanstack/react-start/plugin/vite'
 import viteReact from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
 
+import { isClientAbort } from './src/lib/clientAbort.ts'
 import { allowRemoteRequest } from './src/lib/loopback.ts'
 import { lanAllowedHosts } from './src/server/mobile/lan.ts'
 
@@ -53,6 +54,27 @@ function remoteAccessGuard(): Plugin {
   }
 }
 
+/**
+ * A tab that navigates away mid-render aborts the socket. The request middleware
+ * in `src/start.ts` swallows that, but an abort raced against the first request
+ * of a cold dev server escapes it and h3 prints the 500 itself. Nothing is
+ * broken and nothing can be answered, so keep it out of the dev log.
+ */
+function silenceClientAbortLogs(): Plugin {
+  return {
+    name: 'openrun:silence-client-abort-logs',
+    apply: 'serve',
+    configureServer() {
+      const original = console.error
+      console.error = (...args: unknown[]) => {
+        const [first] = args
+        if (args.length === 1 && first instanceof Error && isClientAbort(first)) return
+        original(...args)
+      }
+    },
+  }
+}
+
 /** Boot unattended work in dev without waiting for the first browser request. */
 function automationBootstrap(): Plugin {
   return {
@@ -83,6 +105,7 @@ const config = defineConfig({
     : undefined,
   plugins: [
     remoteAccessGuard(),
+    silenceClientAbortLogs(),
     automationBootstrap(),
     devtools(),
     tailwindcss(),


### PR DESCRIPTION
An abort raced against a cold dev server's first request escapes the
request middleware, so h3 prints the 500 itself. Share the detector with
a serve-only plugin that drops the log line.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01N8adAqM2UNmT1ZPCJQZfSe

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014irp7qsPXZVzvmYxqK4hqP