### PR TITLE
fix(workspaces): report the branch a workspace HEAD points at

### DIFF
--- a/src/server/git.ts
+++ b/src/server/git.ts
@@ -1091,7 +1091,11 @@ export function remoteUrl(repoPath: string): string {
 }
 
 /** Used to guard workspace archive — refuse to discard work that isn't on the remote. */
-export function hasUnpushedWork(repoPath: string): { dirty: boolean; ahead: number } {
+export function hasUnpushedWork(repoPath: string): {
+  dirty: boolean
+  ahead: number
+  branch: string
+} {
   const info = repoInfo(repoPath)
-  return { dirty: info.dirty, ahead: info.ahead }
+  return { dirty: info.dirty, ahead: info.ahead, branch: info.branch }
 }

--- a/src/server/workspaces.ts
+++ b/src/server/workspaces.ts
@@ -444,11 +444,16 @@ function toWorkspaceWithMeta(db: ReturnType<typeof getDb>, ws: WorkspaceRow): Wo
   // shelling out to git for a path that no longer exists.
   const info =
     ws.status === 'archived' || !existsSync(ws.path)
-      ? { dirty: false, ahead: 0 }
+      ? { dirty: false, ahead: 0, branch: '' }
       : git.hasUnpushedWork(ws.path)
+
+  // The checkout can be switched outside openrun, so HEAD wins over the branch
+  // recorded at creation. Detached HEAD reports "HEAD" — keep the record then.
+  const liveBranch = info.branch && info.branch !== 'HEAD' ? info.branch : ws.branch
 
   return {
     ...ws,
+    branch: liveBranch,
     projectName: project?.name ?? '(deleted project)',
     dirty: info.dirty,
     ahead: info.ahead,


### PR DESCRIPTION
The branch was recorded once at workspace creation, so a `git switch` in
the checkout left the breadcrumb and switcher showing a stale name.
repoInfo already reads HEAD for the dirty/ahead counts.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01N8adAqM2UNmT1ZPCJQZfSe

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014irp7qsPXZVzvmYxqK4hqP