### PR TITLE
feat(tasks): select and bulk delete automations

### DIFF
--- a/changelog.d/bulk-automation-delete.md
+++ b/changelog.d/bulk-automation-delete.md
@@ -1,0 +1,6 @@
+You no longer delete automations one row at a time: the Automations list has
+selection checkboxes and a **Delete selected** button, the same as Runs. Removing
+a batch stops their schedules and cancels any run already in flight.
+
+The checkboxes on both lists are smaller, so they sit inside the row instead of
+crowding the status column.

--- a/src/fns/index.ts
+++ b/src/fns/index.ts
@@ -197,6 +197,13 @@ export const removeTask = createServerFn({ method: 'POST' })
     return { ok: true }
   })
 
+export const deleteTasks = createServerFn({ method: 'POST' })
+  .validator((d: { ids: string[] }) => d)
+  .handler(async ({ data }) => {
+    ;(await core()).deleteTasks(data.ids)
+    return { ok: true }
+  })
+
 export const runTaskNow = createServerFn({ method: 'POST' })
   .validator((d: { id: string }) => d)
   .handler(async ({ data }) => (await core()).runTaskNow(data.id))

--- a/src/lib/listSelection.test.ts
+++ b/src/lib/listSelection.test.ts
@@ -1,0 +1,43 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+import { normalizeSelection, selectionState, toggleSelection } from './listSelection.ts'
+
+const selectable = ['a', 'b']
+
+describe('list selection', () => {
+  it('keeps only selectable ids and removes duplicates', () => {
+    assert.deepEqual(normalizeSelection(['a', 'gone', 'a'], selectable), ['a'])
+  })
+
+  it('returns the existing selection when normalization makes no changes', () => {
+    const selected = ['a']
+    assert.strictEqual(normalizeSelection(selected, selectable), selected)
+  })
+
+  it('reports checked and indeterminate states', () => {
+    assert.deepEqual(selectionState([], selectable), {
+      ids: ['a', 'b'],
+      checked: false,
+      indeterminate: false,
+    })
+    assert.deepEqual(selectionState(['a'], selectable), {
+      ids: ['a', 'b'],
+      checked: false,
+      indeterminate: true,
+    })
+    assert.deepEqual(selectionState(['a', 'b'], selectable), {
+      ids: ['a', 'b'],
+      checked: true,
+      indeterminate: false,
+    })
+  })
+
+  it('reports nothing checked when there is nothing to select', () => {
+    assert.deepEqual(selectionState([], []), { ids: [], checked: false, indeterminate: false })
+  })
+
+  it('adds and removes a single id', () => {
+    assert.deepEqual(toggleSelection(['a'], 'b', true), ['a', 'b'])
+    assert.deepEqual(toggleSelection(['a', 'b'], 'a', false), ['b'])
+  })
+})

--- a/src/lib/listSelection.ts
+++ b/src/lib/listSelection.ts
@@ -1,0 +1,47 @@
+/**
+ * Checkbox selection over a list of rows. Runs and Automations both let you
+ * tick rows and delete the lot, so the state lives here once.
+ */
+
+/** Keep selection scoped to the rows currently visible and still selectable. */
+export function normalizeSelection(
+  selectedIds: readonly string[],
+  selectableIds: readonly string[],
+): string[] {
+  const selectable = new Set(selectableIds)
+  const normalized = [...new Set(selectedIds)].filter((id) => selectable.has(id))
+  if (
+    normalized.length === selectedIds.length &&
+    normalized.every((id, i) => id === selectedIds[i])
+  ) {
+    // Returning the existing state lets React bail out even when a demo or
+    // refetch supplies a fresh visible-rows array on every render.
+    return selectedIds as string[]
+  }
+  return normalized
+}
+
+export function toggleSelection(
+  selectedIds: readonly string[],
+  id: string,
+  checked: boolean,
+): string[] {
+  const selected = new Set(selectedIds)
+  if (checked) selected.add(id)
+  else selected.delete(id)
+  return [...selected]
+}
+
+export function selectionState(
+  selectedIds: readonly string[],
+  selectableIds: readonly string[],
+): { ids: string[]; checked: boolean; indeterminate: boolean } {
+  const ids = [...selectableIds]
+  const selected = new Set(selectedIds)
+  const selectedCount = ids.filter((id) => selected.has(id)).length
+  return {
+    ids,
+    checked: ids.length > 0 && selectedCount === ids.length,
+    indeterminate: selectedCount > 0 && selectedCount < ids.length,
+  }
+}

--- a/src/lib/queries.ts
+++ b/src/lib/queries.ts
@@ -899,6 +899,17 @@ export function useDeleteTask() {
   })
 }
 
+export function useDeleteTasks() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (ids: string[]) => fns.deleteTasks({ data: { ids } }),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['tasks'] })
+      qc.invalidateQueries({ queryKey: ['dashboard'] })
+    },
+  })
+}
+
 // --- Projects & workspaces --------------------------------------------------
 
 export function useProjects(initialData?: fns.ProjectWithMeta[]) {

--- a/src/lib/runSelection.ts
+++ b/src/lib/runSelection.ts
@@ -1,3 +1,5 @@
+import { normalizeSelection, selectionState, toggleSelection } from './listSelection.ts'
+
 export type SelectableRun = { id: string; status: string }
 
 export function deletableRunIds(runs: readonly SelectableRun[]): string[] {
@@ -9,17 +11,7 @@ export function normalizeRunSelection(
   selectedIds: readonly string[],
   visibleRuns: readonly SelectableRun[],
 ): string[] {
-  const visible = new Set(deletableRunIds(visibleRuns))
-  const normalized = [...new Set(selectedIds)].filter((id) => visible.has(id))
-  if (
-    normalized.length === selectedIds.length &&
-    normalized.every((id, i) => id === selectedIds[i])
-  ) {
-    // Returning the existing state lets React bail out even when a demo or
-    // refetch supplies a fresh visible-runs array on every render.
-    return selectedIds as string[]
-  }
-  return normalized
+  return normalizeSelection(selectedIds, deletableRunIds(visibleRuns))
 }
 
 export function toggleRunSelection(
@@ -27,24 +19,14 @@ export function toggleRunSelection(
   runId: string,
   checked: boolean,
 ): string[] {
-  const selected = new Set(selectedIds)
-  if (checked) selected.add(runId)
-  else selected.delete(runId)
-  return [...selected]
+  return toggleSelection(selectedIds, runId, checked)
 }
 
 export function pageSelectionState(
   selectedIds: readonly string[],
   visibleRuns: readonly SelectableRun[],
 ): { ids: string[]; checked: boolean; indeterminate: boolean } {
-  const ids = deletableRunIds(visibleRuns)
-  const selected = new Set(selectedIds)
-  const selectedCount = ids.filter((id) => selected.has(id)).length
-  return {
-    ids,
-    checked: ids.length > 0 && selectedCount === ids.length,
-    indeterminate: selectedCount > 0 && selectedCount < ids.length,
-  }
+  return selectionState(selectedIds, deletableRunIds(visibleRuns))
 }
 
 export function normalizeRunPage(page: number, total: number, pageSize: number): number {

--- a/src/routes/runs.index.tsx
+++ b/src/routes/runs.index.tsx
@@ -25,7 +25,7 @@ export const Route = createFileRoute('/runs/')({
 })
 
 const ROW_GRID =
-  'grid items-center gap-3 grid-cols-[2rem_6.5rem_minmax(0,1fr)_4rem_4.5rem_1.75rem] sm:grid-cols-[2rem_6.5rem_minmax(0,1fr)_8rem_4rem_4.5rem_1.75rem]'
+  'grid items-center gap-3 grid-cols-[1.5rem_6.5rem_minmax(0,1fr)_4rem_4.5rem_1.75rem] sm:grid-cols-[1.5rem_6.5rem_minmax(0,1fr)_8rem_4rem_4.5rem_1.75rem]'
 
 function RunsPage() {
   const demo = isDemoMode()
@@ -169,7 +169,7 @@ function RunsPage() {
                         ? 'No deletable runs on this page'
                         : 'Select all deletable runs on this page'
                     }
-                    className="relative z-10 size-4 accent-[var(--accent)] disabled:cursor-not-allowed disabled:opacity-40"
+                    className="relative z-10 size-3 accent-[var(--accent)] disabled:cursor-not-allowed disabled:opacity-40"
                     onChange={(event) => {
                       event.stopPropagation()
                       const checked = event.currentTarget.checked
@@ -214,7 +214,7 @@ function RunsPage() {
                         disabled={busy || deleteRuns.isPending}
                         aria-label={`Select ${r.chatTitle}`}
                         title={busy ? 'Cancel the run before deleting' : `Select ${r.chatTitle}`}
-                        className="size-4 accent-[var(--accent)] disabled:cursor-not-allowed disabled:opacity-40"
+                        className="size-3 accent-[var(--accent)] disabled:cursor-not-allowed disabled:opacity-40"
                         onChange={(event) => {
                           event.stopPropagation()
                           setSelectedIds((selected) =>

--- a/src/routes/tasks.index.tsx
+++ b/src/routes/tasks.index.tsx
@@ -1,12 +1,13 @@
 import { createFileRoute, Link, useNavigate } from '@tanstack/react-router'
-import { Plus } from 'lucide-react'
-import { useMemo } from 'react'
+import { Plus, Trash2 } from 'lucide-react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { NeedProjectEmpty } from '../components/NeedProjectEmpty'
-import { Button, Card, EmptyState, PageHeader, StatusBadge } from '../components/ui'
+import { Button, Card, EmptyState, Modal, PageHeader, StatusBadge } from '../components/ui'
 import { DEMO_RUNNING_TASK_ID, demoTasks, isDemoMode, type DemoTask } from '../lib/demoData.ts'
 import { absoluteTime, describeSchedule, relativeTime, taskScheduleStatus } from '../lib/format'
+import { normalizeSelection, selectionState, toggleSelection } from '../lib/listSelection.ts'
 import { automationsEmptyKind } from '../lib/projectGate'
-import { useProjects, useRuns, useTasks } from '../lib/queries'
+import { useDeleteTasks, useProjects, useRuns, useTasks } from '../lib/queries'
 import { runNowBlockedReason } from '../lib/runNowGate'
 import { queueDepthLabel } from '../lib/runQueue'
 
@@ -16,7 +17,7 @@ type ListTask = DemoTask | TaskRow
 export const Route = createFileRoute('/tasks/')({ component: TasksPage })
 
 const ROW_GRID =
-  'grid items-center gap-3 grid-cols-[6.5rem_minmax(0,1fr)_minmax(0,7rem)_5rem] sm:grid-cols-[6.5rem_minmax(0,1fr)_8rem_minmax(0,10rem)_5.5rem]'
+  'grid items-center gap-3 grid-cols-[1.5rem_6.5rem_minmax(0,1fr)_minmax(0,7rem)_5rem] sm:grid-cols-[1.5rem_6.5rem_minmax(0,1fr)_8rem_minmax(0,10rem)_5.5rem]'
 
 /**
  * One cell, not eight chips. A blocked automation says the one thing standing
@@ -62,18 +63,65 @@ function TasksPage() {
   )
   const navigate = useNavigate()
   const emptyKind = demo ? null : automationsEmptyKind(projects?.length ?? 0)
+  const deleteTasks = useDeleteTasks()
+  const [selectedIds, setSelectedIds] = useState<string[]>([])
+  const [confirmBulkDelete, setConfirmBulkDelete] = useState(false)
+  const selectAllRef = useRef<HTMLInputElement>(null)
+  const selectableIds = useMemo(() => (tasks ?? []).map((t) => t.id), [tasks])
+  const pageSelection = selectionState(selectedIds, selectableIds)
+  const selectedCount = normalizeSelection(selectedIds, selectableIds).length
+
+  useEffect(() => {
+    setSelectedIds((selected) => normalizeSelection(selected, selectableIds))
+  }, [selectableIds])
+
+  useEffect(() => {
+    if (selectAllRef.current) selectAllRef.current.indeterminate = pageSelection.indeterminate
+  }, [pageSelection.indeterminate])
 
   const newTask = () => navigate({ to: '/tasks/new' })
+
+  const closeBulkDelete = () => {
+    deleteTasks.reset()
+    setConfirmBulkDelete(false)
+  }
+
+  const confirmBulk = async () => {
+    const ids = normalizeSelection(selectedIds, selectableIds)
+    if (ids.length === 0) return
+    try {
+      await deleteTasks.mutateAsync(ids)
+      setSelectedIds((selected) => selected.filter((id) => !ids.includes(id)))
+      closeBulkDelete()
+    } catch {
+      // Keep the modal open so the accessible error can be retried.
+    }
+  }
 
   return (
     <div className="mx-auto max-w-5xl px-6 py-6">
       <PageHeader
         title="Automations"
         actions={
-          <Button variant="primary" onClick={newTask}>
-            <Plus className="h-3.5 w-3.5" />
-            New automation
-          </Button>
+          <div className="flex items-center gap-2">
+            {selectedCount > 0 ? (
+              <Button
+                variant="danger"
+                onClick={() => {
+                  deleteTasks.reset()
+                  setConfirmBulkDelete(true)
+                }}
+                disabled={deleteTasks.isPending}
+              >
+                <Trash2 className="h-3.5 w-3.5" />
+                Delete selected ({selectedCount})
+              </Button>
+            ) : null}
+            <Button variant="primary" onClick={newTask}>
+              <Plus className="h-3.5 w-3.5" />
+              New automation
+            </Button>
+          </div>
         }
       />
 
@@ -82,6 +130,32 @@ function TasksPage() {
       ) : tasks && tasks.length > 0 ? (
         <Card className="divide-y divide-[var(--border-quaternary)]">
           <div className={`${ROW_GRID} px-4 py-2 text-ui-sm text-tier-quaternary`}>
+            <span>
+              <input
+                ref={selectAllRef}
+                type="checkbox"
+                checked={pageSelection.checked}
+                disabled={selectableIds.length === 0 || deleteTasks.isPending}
+                aria-label="Select all automations"
+                title={
+                  selectableIds.length === 0 ? 'No automations to select' : 'Select all automations'
+                }
+                className="relative z-10 size-3 accent-[var(--accent)] disabled:cursor-not-allowed disabled:opacity-40"
+                onChange={(event) => {
+                  event.stopPropagation()
+                  const checked = event.currentTarget.checked
+                  setSelectedIds((selected) => {
+                    const next = new Set(selected)
+                    for (const id of selectableIds) {
+                      if (checked) next.add(id)
+                      else next.delete(id)
+                    }
+                    return [...next]
+                  })
+                }}
+                onClick={(event) => event.stopPropagation()}
+              />
+            </span>
             <span>Status</span>
             <span>Automation</span>
             <span className="hidden sm:block">Runtime</span>
@@ -108,6 +182,23 @@ function TasksPage() {
                   className="absolute inset-0"
                   aria-label={t.name}
                 />
+                <span className="relative z-10 flex items-center">
+                  <input
+                    type="checkbox"
+                    checked={selectedIds.includes(t.id)}
+                    disabled={deleteTasks.isPending}
+                    aria-label={`Select ${t.name}`}
+                    title={`Select ${t.name}`}
+                    className="size-3 accent-[var(--accent)] disabled:cursor-not-allowed disabled:opacity-40"
+                    onChange={(event) => {
+                      event.stopPropagation()
+                      setSelectedIds((selected) =>
+                        toggleSelection(selected, t.id, event.currentTarget.checked),
+                      )
+                    }}
+                    onClick={(event) => event.stopPropagation()}
+                  />
+                </span>
                 <StatusBadge status={taskScheduleStatus(!!t.enabled, runningTaskIds.has(t.id))} />
                 <span className="truncate text-ui-base text-foreground">{t.name}</span>
                 <span className="hidden truncate text-ui-sm text-tier-quaternary sm:block">
@@ -141,6 +232,40 @@ function TasksPage() {
           </div>
         </EmptyState>
       )}
+
+      {confirmBulkDelete ? (
+        <Modal title="Delete selected automations" onClose={closeBulkDelete}>
+          <div className="space-y-4">
+            <p className="text-ui-base text-tier-secondary">
+              Permanently delete{' '}
+              <span className="text-foreground">{selectedCount} selected automations</span>? Their
+              schedules stop and any run already in flight is cancelled. This cannot be undone.
+            </p>
+            {deleteTasks.isError ? (
+              <p
+                role="alert"
+                className="rounded-md border border-danger px-3 py-2 text-ui-base text-danger"
+              >
+                {deleteTasks.error instanceof Error
+                  ? deleteTasks.error.message
+                  : String(deleteTasks.error)}
+              </p>
+            ) : null}
+            <div className="flex justify-end gap-2 pt-1">
+              <Button variant="ghost" onClick={closeBulkDelete}>
+                Cancel
+              </Button>
+              <Button
+                variant="danger"
+                onClick={() => void confirmBulk()}
+                disabled={deleteTasks.isPending || selectedCount === 0}
+              >
+                {deleteTasks.isPending ? 'Deleting…' : `Delete ${selectedCount} automations`}
+              </Button>
+            </div>
+          </div>
+        </Modal>
+      ) : null}
     </div>
   )
 }

--- a/src/server/core.ts
+++ b/src/server/core.ts
@@ -1298,6 +1298,10 @@ export function deleteTask(taskId: string) {
   getDb().prepare('DELETE FROM tasks WHERE id = ?').run(taskId)
 }
 
+export function deleteTasks(taskIds: string[]): void {
+  for (const id of [...new Set(taskIds)]) deleteTask(id)
+}
+
 /** Runs parked because their workspace was busy, oldest first. */
 export function listPendingRuns() {
   const db = getDb()


### PR DESCRIPTION
## Summary
- The Automations list now has a checkbox on every row and a select-all in the header, with a **Delete selected (n)** action beside **New automation**. Confirming stops those schedules and cancels any run already in flight.
- Checkboxes on both the Automations and Runs lists are smaller (`size-3`), so they sit inside the row rather than crowding the status column.
- Run and automation selection now share one `lib/listSelection.ts` module instead of two copies of the same state logic.

Closes #41

## Test plan
- [ ] `/tasks` — tick two automations, click **Delete selected (2)**, confirm; both rows disappear and neither fires again
- [ ] `/tasks` — header checkbox selects every row, goes indeterminate when one row is unticked, and clears the selection when unticked
- [ ] `/tasks` — delete a batch that includes an automation with a run in flight; the run is cancelled rather than left orphaned
- [ ] `/runs` — selection and bulk delete still work, with the smaller checkbox aligned in the row