### PR TITLE
fix(cloud): release device on sign-out

### DIFF
--- a/changelog.d/cloud-sign-out-device.md
+++ b/changelog.d/cloud-sign-out-device.md
@@ -1,0 +1,1 @@
+- Signing out no longer leaves this installation permanently claimed by the previous Open Run account. The device is revoked remotely when possible and gets a fresh local identity, so you can immediately sign in with another account even if the control plane was temporarily unreachable.

--- a/src/server/cloud/index.ts
+++ b/src/server/cloud/index.ts
@@ -4,7 +4,7 @@
  * Safe to boot when unsigned — startCloudRelay no-ops without a session.
  */
 import { restartCloudRelay, startCloudRelay, stopCloudRelay } from './relay.ts'
-import { signOutCloud } from './login.ts'
+import { disconnectCloud } from './login.ts'
 import { forgetCloudProviders } from './providers.ts'
 
 export { getCloudStatus } from './status.ts'
@@ -35,7 +35,7 @@ export function bootCloud(): void {
 
 export async function signOutAndDisconnect(): Promise<void> {
   stopCloudRelay()
-  signOutCloud()
+  await disconnectCloud()
   forgetCloudProviders()
 }
 

--- a/src/server/cloud/login.ts
+++ b/src/server/cloud/login.ts
@@ -20,6 +20,7 @@ import {
   readCloudSession,
   readMachineId,
   readPkcePending,
+  resetMachineId,
   writeCloudSession,
   writeConnectPending,
   writePkcePending,
@@ -51,6 +52,9 @@ function deviceName(): string {
 export async function startCloudLogin(origin: string, next?: string): Promise<{ url: string }> {
   const cloudUrl = configuredCloudUrl()
   if (!cloudUrl) throw new Error('Cloud is turned off (AGENTOPS_CLOUD_URL=off).')
+  // Older versions left the machine id claimed after sign-out. A fresh id
+  // repairs those installs without weakening server-side ownership checks.
+  if (!readCloudSession()) resetMachineId()
   const { verifier, challenge } = await createPkcePair()
   const state = randomOAuthState()
   const redirectUri = localCloudCallbackUrl(origin)
@@ -173,6 +177,26 @@ export async function currentAccessToken(): Promise<string | null> {
 export function signOutCloud(): void {
   clearCloudSession()
   clearPkcePending()
+}
+
+/** Revoke remotely, then rotate the id so an offline sign-out cannot lock out the next account. */
+export async function disconnectCloud(): Promise<void> {
+  const session = readCloudSession()
+  const cloudUrl = configuredCloudUrl()
+  try {
+    if (session && cloudUrl) {
+      await fetch(`${cloudUrl}${CLOUD_PATHS.token}`, {
+        method: 'DELETE',
+        headers: { authorization: `Bearer ${session.accessToken}` },
+        signal: AbortSignal.timeout(5_000),
+      })
+    }
+  } catch (err) {
+    console.error('[cloud] remote sign out failed; continuing locally', err)
+  } finally {
+    signOutCloud()
+    resetMachineId()
+  }
 }
 
 /**

--- a/src/server/cloud/session.test.ts
+++ b/src/server/cloud/session.test.ts
@@ -9,9 +9,13 @@ test('machine id is stable across reads', async () => {
   const prev = process.env.OPENRUN_HOME
   process.env.OPENRUN_HOME = home
   try {
-    const { readMachineId, readCloudSession, writeCloudSession, clearCloudSession } = await import(
-      './session.ts'
-    )
+    const {
+      readMachineId,
+      readCloudSession,
+      writeCloudSession,
+      clearCloudSession,
+      resetMachineId,
+    } = await import('./session.ts')
     const a = readMachineId()
     const b = readMachineId()
     assert.equal(a, b)
@@ -30,6 +34,8 @@ test('machine id is stable across reads', async () => {
     assert.equal(session?.accessExpiresAt, 1_700_000_000_000)
     clearCloudSession()
     assert.equal(readCloudSession(), null)
+    resetMachineId()
+    assert.notEqual(readMachineId(), a)
   } finally {
     if (prev === undefined) delete process.env.OPENRUN_HOME
     else process.env.OPENRUN_HOME = prev

--- a/src/server/cloud/session.ts
+++ b/src/server/cloud/session.ts
@@ -46,6 +46,12 @@ export function readMachineId(): string {
   return id
 }
 
+/** The next cloud sign-in represents this installation as a new device. */
+export function resetMachineId(): void {
+  const file = machineIdPath()
+  if (existsSync(file)) unlinkSync(file)
+}
+
 export function readCloudSession(): CloudSessionStored | null {
   const file = cloudSessionPath()
   if (!existsSync(file)) return null


### PR DESCRIPTION
## Summary
- Signing out releases this device from the prior Open Run account.
- A fresh device identity lets the next account sign in even if remote revocation is temporarily unavailable.

## Test plan
- [x] Run `pnpm test` and confirm the cloud session suite passes.
- [x] Sign out from Settings, then sign in as another account and confirm the device connects.