### PR TITLE
fix(security): confine the mobile api path prefix

### DIFF
--- a/changelog.d/mobile-api-path-and-lan-host.md
+++ b/changelog.d/mobile-api-path-and-lan-host.md
@@ -1,5 +1,3 @@
-- The LAN mobile API no longer treats any URL that merely *starts with*
-  `/api/mobile/` as in-bounds, so `../` and `%2e%2e` cannot walk onto desktop
-  routes. When mobile is on, this machine's LAN addresses are allowed Host
-  names, so pairing no longer needs `OPENRUN_ALLOWED_HOSTS` set to the phone's
-  view of your Mac.
+You no longer risk a mobile API URL that merely *starts with* `/api/mobile/` walking onto desktop routes — `../` and `%2e%2e` are now resolved and refused.
+
+When mobile is on, Open Run accepts this machine’s LAN IPs as Host names, so pairing no longer needs `OPENRUN_ALLOWED_HOSTS` set to your phone’s view of your Mac.

--- a/changelog.d/mobile-api-path-and-lan-host.md
+++ b/changelog.d/mobile-api-path-and-lan-host.md
@@ -1,0 +1,5 @@
+- The LAN mobile API no longer treats any URL that merely *starts with*
+  `/api/mobile/` as in-bounds, so `../` and `%2e%2e` cannot walk onto desktop
+  routes. When mobile is on, this machine's LAN addresses are allowed Host
+  names, so pairing no longer needs `OPENRUN_ALLOWED_HOSTS` set to the phone's
+  view of your Mac.

--- a/src/lib/loopback.test.ts
+++ b/src/lib/loopback.test.ts
@@ -34,9 +34,17 @@ test('a missing address is not loopback', () => {
 test('only the mobile API prefix matches', () => {
   assert.equal(isMobileApiPath('/api/mobile/me'), true)
   assert.equal(isMobileApiPath('/api/mobile/runs/run_1/stream'), true)
+  assert.equal(isMobileApiPath('/api/mobile/me?x=1'), true)
   assert.equal(isMobileApiPath('/api/activity/stream'), false)
   assert.equal(isMobileApiPath('/'), false)
   assert.equal(isMobileApiPath('/api/mobile'), false, 'prefix must be a path segment')
+})
+
+test('dot-dot and encoded traversal are not the mobile API', () => {
+  assert.equal(isMobileApiPath('/api/mobile/../api/runs/run_1/stream'), false)
+  assert.equal(isMobileApiPath('/api/mobile/%2e%2e/api/runs/run_1/stream'), false)
+  assert.equal(isMobileApiPath('/api/mobile/%2e%2e/%2e%2e/_serverFn/x'), false)
+  assert.equal(isMobileApiPath('//api/mobile/me'), false)
 })
 
 test('a path that merely mentions the prefix later does not match', () => {

--- a/src/lib/loopback.ts
+++ b/src/lib/loopback.ts
@@ -27,7 +27,28 @@ export function isLoopbackAddress(address: string | undefined | null): boolean {
 /** Requests a non-loopback caller may make when the mobile surface is on. */
 export function isMobileApiPath(url: string | undefined | null): boolean {
   if (!url) return false
-  return url.startsWith('/api/mobile/')
+  // Node gives path + query. `//…` is protocol-relative — not a local path.
+  const raw = url.split(/[?#]/, 1)[0] ?? ''
+  if (!raw.startsWith('/') || raw.startsWith('//')) return false
+  let decoded: string
+  try {
+    decoded = decodeURIComponent(raw)
+  } catch {
+    return false
+  }
+  const parts: string[] = []
+  for (const part of decoded.split('/')) {
+    if (part === '' || part === '.') continue
+    if (part === '..') {
+      if (parts.length === 0) return false
+      parts.pop()
+      continue
+    }
+    parts.push(part)
+  }
+  // Prefix must be a path segment: `/api/mobile/me`, not `/api/mobile` itself
+  // and not `/api/mobile/../api/runs/…` after `..` is applied.
+  return parts[0] === 'api' && parts[1] === 'mobile' && parts.length >= 3
 }
 
 /**

--- a/src/lib/serverAccess.test.ts
+++ b/src/lib/serverAccess.test.ts
@@ -9,6 +9,7 @@ import {
   insecureHostWarning,
   isDocumentRequest,
   isLoopbackHost,
+  mergeAllowedHosts,
   parseAllowedHosts,
   serverBindRefusal,
   tokenRequiredForRequests,
@@ -205,6 +206,20 @@ test('allowed-host lists are parsed leniently', () => {
   assert.deepEqual(parseAllowedHosts('a.test, b.test:8080 ,,'), ['a.test', 'b.test'])
   assert.deepEqual(parseAllowedHosts(''), [])
   assert.deepEqual(parseAllowedHosts(undefined), [])
+})
+
+test('mergeAllowedHosts unions LAN IPs onto the configured list', () => {
+  assert.deepEqual(mergeAllowedHosts(['tunnel.example'], ['192.168.1.24', '10.0.0.5:3000']), [
+    'tunnel.example',
+    '192.168.1.24',
+    '10.0.0.5',
+  ])
+  const config = {
+    ...loopbackBind,
+    allowedHosts: mergeAllowedHosts([], ['192.168.1.24']),
+  }
+  assert.equal(hostHeaderRefusal(config, '192.168.1.24:3000'), null)
+  assert.ok(hostHeaderRefusal(config, 'evil.example'))
 })
 
 test('a published bind is not host-checked — it has names we cannot enumerate', () => {

--- a/src/lib/serverAccess.ts
+++ b/src/lib/serverAccess.ts
@@ -244,6 +244,16 @@ export function parseAllowedHosts(raw: string | null | undefined): string[] {
     .filter((entry): entry is string => entry !== null)
 }
 
+/** Union of configured extra names and (when mobile is on) this machine's LAN IPs. */
+export function mergeAllowedHosts(configured: string[], extra: string[]): string[] {
+  const hosts = new Set(configured)
+  for (const entry of extra) {
+    const name = hostnameFromHostHeader(entry)
+    if (name) hosts.add(name)
+  }
+  return [...hosts]
+}
+
 /**
  * Why a request's `Host` header disqualifies it, or `null` to let it through.
  *

--- a/src/server/accessToken.ts
+++ b/src/server/accessToken.ts
@@ -17,6 +17,7 @@ import {
   hostHeaderRefusal,
   insecureHostWarning,
   isDocumentRequest,
+  mergeAllowedHosts,
   parseAllowedHosts,
   serverBindRefusal,
   tokenRequiredForRequests,
@@ -27,6 +28,8 @@ import {
 } from '../lib/serverAccess.ts'
 import { openrunEnv } from '../lib/openrunEnv.ts'
 import { openrunHome } from './db.ts'
+import { mobileEnabled } from './mobile/config.ts'
+import { lanAddresses } from './mobile/lan.ts'
 
 /** Owner read/write only. Anything wider and the token is not a secret. */
 const OWNER_ONLY = 0o600
@@ -102,7 +105,10 @@ export function serverAccessConfig(): ServerAccessConfig {
     host: resolveHost(),
     hasToken: resolveAccessToken() !== null,
     allowInsecureHost: allowInsecureHost(),
-    allowedHosts: parseAllowedHosts(openrunEnv('ALLOWED_HOSTS')),
+    allowedHosts: mergeAllowedHosts(
+      parseAllowedHosts(openrunEnv('ALLOWED_HOSTS')),
+      mobileEnabled() ? lanAddresses() : [],
+    ),
   }
 }
 


### PR DESCRIPTION
## Summary
- The LAN mobile API no longer treats any URL that merely *starts with* `/api/mobile/` as in-bounds. `isMobileApiPath` strips the query, rejects protocol-relative `//…`, decodes percent-escapes and resolves `.` / `..` segments, so `/api/mobile/../api/runs/…` and `/api/mobile/%2e%2e/_serverFn/x` can no longer walk onto desktop routes.
- When the mobile surface is on, this machine's own LAN addresses are accepted as `Host` names, so pairing a phone no longer needs `OPENRUN_ALLOWED_HOSTS` set by hand to whatever the phone calls your Mac.

## Test plan
- [ ] `pnpm dev:mobile`, pair a phone over the LAN with no `OPENRUN_ALLOWED_HOSTS` set — the phone reaches `/api/mobile/*` and the run list loads
- [ ] From the phone, request `http://<mac-lan-ip>:3000/api/mobile/%2e%2e/_serverFn/listRuns` — refused, not proxied onto the desktop route
- [ ] With mobile off, a non-loopback `Host` is still refused as before