### PR TITLE
feat: keep app state in ~/.openrun

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -323,8 +323,10 @@ one-paragraph import, never a restatement.
   `pnpm generate-routes`: the standalone router-cli currently emits a different `Register`
   block from the Vite plugin, dropping the `config` entry that types the `src/start.ts`
   instance. The plugin's output is authoritative.
-- `data/openrun.db` is git-ignored and created on first run; delete it to reset all state.
-  App-managed clones and worktrees live in `~/.openrun` (`OPENRUN_HOME` overrides).
+- Runs, automations, and the rest of app state live in `~/.openrun/openrun.db`
+  (`OPENRUN_HOME` overrides the whole directory). Delete that file to reset.
+  A leftover `data/openrun.db` in a checkout is moved there on first boot.
+  App-managed clones and worktrees live under the same home directory.
 - The scheduler and both live pub/sub registries are **module singletons guarded on
   `globalThis`** so they survive Vite HMR. Don't re-instantiate them per call.
 - `db.ts` migrations are additive-only (`addColumn` diffs `table_info`; SQLite has no

--- a/changelog.d/home-database.md
+++ b/changelog.d/home-database.md
@@ -1,0 +1,5 @@
+- Switching git worktree or clone no longer starts you from an empty app.
+  Runs, automations, and projects live in `~/.openrun` with the rest of Open
+  Run's machine state, so every checkout on the same account sees the same
+  local data. A leftover `data/openrun.db` in a repo is moved there on first
+  boot.

--- a/changelog.d/secrets-at-rest.md
+++ b/changelog.d/secrets-at-rest.md
@@ -1,3 +1,3 @@
 You no longer lose MCP OAuth tokens, notification webhook URLs, or APNs
-tokens if someone copies `data/openrun.db`. Those values are sealed with a
+tokens if someone copies `openrun.db`. Those values are sealed with a
 key that lives in `~/.openrun/data-key`, not in the database.

--- a/scripts/mcp-server.ts
+++ b/scripts/mcp-server.ts
@@ -27,9 +27,9 @@ import {
 import { callOpenrunTool } from '../src/server/openrunTools.ts'
 
 /**
- * The agent spawned us inside the worktree, and the database path is resolved
- * from the working directory — so move to Open Run's own directory first, and
- * refuse to answer rather than create an empty database in the user's repo.
+ * The agent spawned us inside the worktree. The database lives under
+ * `OPENRUN_HOME`, but we still chdir to Open Run's own directory and refuse
+ * to answer without it — a hand-started process is not attached to a run.
  */
 function enterAppDir(): boolean {
   const dir = process.env[OPENRUN_APP_DIR_ENV] ?? ''

--- a/src/lib/openrunTools.ts
+++ b/src/lib/openrunTools.ts
@@ -36,10 +36,10 @@ export const OPENRUN_RUN_ID_ENV = 'OPENRUN_RUN_ID'
 /**
  * Env var carrying the directory Open Run itself runs from.
  *
- * The server process is spawned by the agent, so it inherits the *worktree* as
- * its cwd — and the database path is resolved from cwd. Without this the
- * server would quietly create an empty `data/openrun.db` inside the user's
- * repository instead of reading the real one.
+ * The server process is spawned by the agent inside the worktree. The
+ * database lives under `OPENRUN_HOME`, so this is no longer how we find it;
+ * the MCP stdio server still requires it as proof the process was started by
+ * Open Run rather than by hand.
  */
 export const OPENRUN_APP_DIR_ENV = 'OPENRUN_APP_DIR'
 

--- a/src/server/db.test.ts
+++ b/src/server/db.test.ts
@@ -1,22 +1,27 @@
 /**
  * Boot the schema the way a new install does: an empty directory, nothing to
- * migrate from. `getDb()` resolves the file from the cwd, hence the chdir.
+ * migrate from. `getDb()` resolves the file from `OPENRUN_HOME`.
  */
 import assert from 'node:assert/strict'
-import { existsSync, mkdtempSync, rmSync } from 'node:fs'
+import { existsSync, mkdirSync, mkdtempSync, renameSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { after, describe, it } from 'node:test'
 
 const root = mkdtempSync(join(tmpdir(), 'openrun-db-'))
+const home = join(root, '.openrun')
 const cwdBefore = process.cwd()
+const previousHome = process.env.OPENRUN_HOME
+process.env.OPENRUN_HOME = home
 process.chdir(root)
 
-const { getDb, closeDb, openrunHome } = await import('./db.ts')
+const { getDb, closeDb, openrunDbPath, openrunHome } = await import('./db.ts')
 
 after(() => {
   closeDb()
   process.chdir(cwdBefore)
+  if (previousHome === undefined) delete process.env.OPENRUN_HOME
+  else process.env.OPENRUN_HOME = previousHome
   rmSync(root, { recursive: true, force: true })
 })
 
@@ -29,7 +34,7 @@ function columns(table: string): string[] {
 describe('a brand-new database', () => {
   it('boots without a migration reaching a table that does not exist yet', () => {
     assert.doesNotThrow(() => getDb())
-    assert.ok(existsSync(join(root, 'data', 'openrun.db')))
+    assert.ok(existsSync(openrunDbPath()))
   })
 
   it('gives a fresh install the same columns an upgraded one has', () => {
@@ -64,9 +69,26 @@ describe('a brand-new database', () => {
     process.env.OPENRUN_HOME = join(root, 'custom-home')
     try {
       assert.equal(openrunHome(), join(root, 'custom-home'))
+      assert.equal(openrunDbPath(), join(root, 'custom-home', 'openrun.db'))
     } finally {
       if (previous === undefined) delete process.env.OPENRUN_HOME
       else process.env.OPENRUN_HOME = previous
     }
+  })
+
+  it('moves a leftover checkout database into OPENRUN_HOME', () => {
+    getDb()
+    closeDb()
+    const homeDb = openrunDbPath()
+    const leftover = join(root, 'data', 'openrun.db')
+    mkdirSync(join(root, 'data'), { recursive: true })
+    renameSync(homeDb, leftover)
+    for (const suffix of ['-wal', '-shm'] as const) {
+      if (existsSync(homeDb + suffix)) renameSync(homeDb + suffix, leftover + suffix)
+    }
+
+    getDb()
+    assert.ok(existsSync(homeDb))
+    assert.equal(existsSync(leftover), false)
   })
 })

--- a/src/server/db.ts
+++ b/src/server/db.ts
@@ -1,17 +1,18 @@
 /**
  * SQLite persistence layer.
  *
- * Everything is stored in a single local file (./data/openrun.db) so the whole
- * proof-of-concept is self-contained and requires no external services. This
- * module is server-only — it is never imported into client bundles (route
- * components reach it exclusively through server functions).
+ * App state (runs, automations, projects) lives in `~/.openrun/openrun.db`,
+ * next to the wrapping key and managed clones — one machine, one dataset,
+ * regardless of which checkout you boot from. `OPENRUN_HOME` relocates the
+ * whole directory. This module is server-only — it is never imported into
+ * client bundles (route components reach it exclusively through server
+ * functions).
  */
 import Database from 'better-sqlite3'
 import { spawnSync } from 'node:child_process'
 import { chmodSync, existsSync, mkdirSync, renameSync } from 'node:fs'
 import * as os from 'node:os'
 import * as path from 'node:path'
-import { dirname, resolve } from 'node:path'
 import { openrunEnv } from '../lib/openrunEnv.ts'
 import { RUNTIME_PRESETS } from '../lib/runtimePresets.ts'
 import { ensureProcessPathAugmented } from './userPath.ts'
@@ -418,11 +419,12 @@ export type WorkspaceRow = {
 // ---------------------------------------------------------------------------
 
 /**
- * Root directory for everything this app manages on disk (managed clones,
- * worktrees). Worktrees for a project always live under here rather than
- * inside the project's own repo directory — that keeps them out of the way
- * of the user's own editor/working copy and means removing a workspace never
- * risks touching files the user didn't ask us to manage.
+ * Root directory for everything this app manages on disk (the database,
+ * wrapping key, managed clones, worktrees). Worktrees for a project always
+ * live under here rather than inside the project's own repo directory — that
+ * keeps them out of the way of the user's own editor/working copy and means
+ * removing a workspace never risks touching files the user didn't ask us to
+ * manage.
  */
 export function openrunHome(): string {
   const fromEnv = openrunEnv('HOME')
@@ -443,6 +445,10 @@ export function openrunHome(): string {
   return next
 }
 
+export function openrunDbPath(): string {
+  return path.join(openrunHome(), 'openrun.db')
+}
+
 /** Filesystem/URL-safe slug for project and branch directory names. */
 export function slugify(s: string): string {
   return s
@@ -454,14 +460,14 @@ export function slugify(s: string): string {
 
 const DB_SIDECARS = ['-wal', '-shm'] as const
 
-/**
- * True when `file` is a SQLite database that no one ever finished setting up.
- *
- * A healthy boot seeds `runtimes` from `RUNTIME_PRESETS`, so an openable file
- * with no runtimes and no projects is the residue of a process that died
- * partway through `getDb()` — not something worth keeping.
- */
-function isAbandonedDatabase(file: string): boolean {
+type DatabaseCounts = {
+  runtimes: number
+  projects: number
+  runs: number
+  tasks: number
+}
+
+function databaseCounts(file: string): DatabaseCounts | null {
   let probe: Database.Database | null = null
   try {
     probe = new Database(file, { readonly: true, fileMustExist: true })
@@ -472,10 +478,14 @@ function isAbandonedDatabase(file: string): boolean {
       if (row.n === 0) return 0
       return (probe!.prepare(`SELECT count(*) AS n FROM ${table}`).get() as { n: number }).n
     }
-    return counted('runtimes') === 0 && counted('projects') === 0
+    return {
+      runtimes: counted('runtimes'),
+      projects: counted('projects'),
+      runs: counted('runs'),
+      tasks: counted('tasks'),
+    }
   } catch {
-    // Unreadable or not SQLite at all — equally not worth keeping.
-    return true
+    return null
   } finally {
     try {
       probe?.close()
@@ -483,6 +493,26 @@ function isAbandonedDatabase(file: string): boolean {
       // Nothing to do; we only ever read.
     }
   }
+}
+
+/**
+ * True when `file` is a SQLite database that no one ever finished setting up.
+ *
+ * A healthy boot seeds `runtimes` from `RUNTIME_PRESETS`, so an openable file
+ * with no runtimes and no projects is the residue of a process that died
+ * partway through `getDb()` — not something worth keeping.
+ */
+function isAbandonedDatabase(file: string): boolean {
+  const counts = databaseCounts(file)
+  if (!counts) return true
+  return counts.runtimes === 0 && counts.projects === 0
+}
+
+/** Seeded presets only — never used for a project, automation, or run. */
+function isUnusedInstall(file: string): boolean {
+  const counts = databaseCounts(file)
+  if (!counts) return true
+  return counts.projects === 0 && counts.runs === 0 && counts.tasks === 0
 }
 
 function moveWithSidecars(from: string, to: string): void {
@@ -493,20 +523,22 @@ function moveWithSidecars(from: string, to: string): void {
 }
 
 /**
- * Adopt `data/agentops.db` under its new name, once.
+ * Move `legacy` onto `next`, once.
  *
- * The rename shipped with a read-only fallback ("use legacy if openrun.db is
- * absent"), which is a one-way trap: anything that creates an empty
- * `openrun.db` — a build served from a stale cwd, a boot killed mid-migration —
- * permanently hides a database full of real projects and runs, and the app
- * comes up looking factory-reset. So move the file instead of reading past it,
- * and refuse to let an abandoned stub shadow a legacy DB that still has data.
+ * A read-only fallback ("use the old file if the new one is absent") is a
+ * one-way trap: anything that creates an empty `openrun.db` — a build served
+ * from a stale cwd, a boot killed mid-migration — permanently hides a
+ * database full of real projects and runs, and the app comes up looking
+ * factory-reset. So move the file instead of reading past it, and refuse to
+ * let an abandoned stub shadow a legacy DB that still has data.
  */
 function adoptLegacyDatabase(next: string, legacy: string): string {
   if (!existsSync(legacy)) return next
 
   if (existsSync(next)) {
-    if (!isAbandonedDatabase(next)) return next
+    const nextYields =
+      isAbandonedDatabase(next) || (isUnusedInstall(next) && !isUnusedInstall(legacy))
+    if (!nextYields) return next
     try {
       moveWithSidecars(next, `${next}.abandoned-${Date.now()}`)
     } catch {
@@ -524,15 +556,31 @@ function adoptLegacyDatabase(next: string, legacy: string): string {
   return next
 }
 
+/**
+ * Canonical path, adopting a leftover checkout database if we have never
+ * written one under `OPENRUN_HOME`.
+ *
+ * Older builds stored `data/openrun.db` (and before that `data/agentops.db`)
+ * next to the process cwd, so each git worktree looked empty. First boot
+ * after the move picks that file up rather than starting from scratch.
+ */
+function resolveDatabasePath(): string {
+  const home = openrunHome()
+  if (!existsSync(home)) mkdirSync(home, { recursive: true, mode: 0o700 })
+
+  const next = openrunDbPath()
+  const cwdNext = path.resolve(process.cwd(), 'data', 'openrun.db')
+  const cwdLegacy = path.resolve(process.cwd(), 'data', 'agentops.db')
+  const fromCwd = existsSync(cwdNext) ? cwdNext : cwdLegacy
+  return adoptLegacyDatabase(next, fromCwd)
+}
+
 let _db: Database.Database | null = null
 
 export function getDb(): Database.Database {
   if (_db) return _db
 
-  const next = resolve(process.cwd(), 'data', 'openrun.db')
-  const legacy = resolve(process.cwd(), 'data', 'agentops.db')
-  if (!existsSync(dirname(next))) mkdirSync(dirname(next), { recursive: true })
-  const dbPath = adoptLegacyDatabase(next, legacy)
+  const dbPath = resolveDatabasePath()
 
   const db = new Database(dbPath)
   db.pragma('journal_mode = WAL')

--- a/src/server/openrunTools.test.ts
+++ b/src/server/openrunTools.test.ts
@@ -1,6 +1,6 @@
 /**
  * The tool server reads the database and the run's worktree, so these tests use
- * a throwaway cwd (where `getDb()` resolves from) and a real one-commit repo.
+ * a throwaway OPENRUN_HOME and a real one-commit repo.
  */
 import assert from 'node:assert/strict'
 import { execFileSync } from 'node:child_process'
@@ -12,9 +12,8 @@ import { after, before, describe, it } from 'node:test'
 const root = mkdtempSync(join(tmpdir(), 'openrun-tools-'))
 const repo = mkdtempSync(join(tmpdir(), 'openrun-tools-repo-'))
 const cwdBefore = process.cwd()
-
-// getDb() resolves `data/openrun.db` from the cwd at first call, so the chdir
-// has to happen before anything touches the module.
+const previousHome = process.env.OPENRUN_HOME
+process.env.OPENRUN_HOME = join(root, '.openrun')
 process.chdir(root)
 
 const { getDb, closeDb } = await import('./db.ts')
@@ -111,6 +110,8 @@ before(() => {
 after(() => {
   closeDb()
   process.chdir(cwdBefore)
+  if (previousHome === undefined) delete process.env.OPENRUN_HOME
+  else process.env.OPENRUN_HOME = previousHome
   rmSync(root, { recursive: true, force: true })
   rmSync(repo, { recursive: true, force: true })
 })

--- a/src/server/runQueue.test.ts
+++ b/src/server/runQueue.test.ts
@@ -27,6 +27,8 @@ for (const [project, workspace, branch] of [
 }
 
 const cwdBefore = process.cwd()
+const previousHome = process.env.OPENRUN_HOME
+process.env.OPENRUN_HOME = join(root, '.openrun')
 process.chdir(root)
 const vite = await createServer({
   root: appRoot,
@@ -47,6 +49,8 @@ after(async () => {
   closeDb()
   await vite.close()
   process.chdir(cwdBefore)
+  if (previousHome === undefined) delete process.env.OPENRUN_HOME
+  else process.env.OPENRUN_HOME = previousHome
   rmSync(root, { recursive: true, force: true })
 })
 

--- a/src/server/scheduleFires.test.ts
+++ b/src/server/scheduleFires.test.ts
@@ -6,6 +6,8 @@ import { after, describe, it } from 'node:test'
 
 const root = mkdtempSync(join(tmpdir(), 'openrun-schedule-fires-'))
 const cwdBefore = process.cwd()
+const previousHome = process.env.OPENRUN_HOME
+process.env.OPENRUN_HOME = join(root, '.openrun')
 process.chdir(root)
 
 const { closeDb } = await import('./db.ts')
@@ -16,6 +18,8 @@ const { latestScheduleFires, recordScheduleFire, settleScheduleFire } = await im
 after(() => {
   closeDb()
   process.chdir(cwdBefore)
+  if (previousHome === undefined) delete process.env.OPENRUN_HOME
+  else process.env.OPENRUN_HOME = previousHome
   rmSync(root, { recursive: true, force: true })
 })
 

--- a/src/server/scheduler.test.ts
+++ b/src/server/scheduler.test.ts
@@ -23,6 +23,8 @@ execFileSync('git', ['worktree', 'add', '-q', '-b', 'openrun/scheduler', worktre
 })
 
 const cwdBefore = process.cwd()
+const previousHome = process.env.OPENRUN_HOME
+process.env.OPENRUN_HOME = join(root, '.openrun')
 process.chdir(root)
 const vite = await createServer({
   root: appRoot,
@@ -41,6 +43,8 @@ after(async () => {
   closeDb()
   await vite.close()
   process.chdir(cwdBefore)
+  if (previousHome === undefined) delete process.env.OPENRUN_HOME
+  else process.env.OPENRUN_HOME = previousHome
   rmSync(root, { recursive: true, force: true })
 })
 

--- a/src/server/usage.test.ts
+++ b/src/server/usage.test.ts
@@ -1,6 +1,6 @@
 /**
  * Each CLI's real history layout is built on disk and its home override points
- * at it. The chdir is for `usage_file_cache`, which `getDb()` resolves by cwd.
+ * at it. OPENRUN_HOME isolates `usage_file_cache` from the developer's database.
  */
 import assert from 'node:assert/strict'
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
@@ -13,6 +13,8 @@ const home = join(root, 'home')
 const project = join(root, 'code', 'openrun')
 const worktree = join(project, '.worktrees', 'fix')
 const cwdBefore = process.cwd()
+const previousHome = process.env.OPENRUN_HOME
+process.env.OPENRUN_HOME = join(root, '.openrun')
 process.chdir(root)
 
 process.env.OPENRUN_CLAUDE_LIMITS = '0'
@@ -169,6 +171,8 @@ before(() => {
 after(() => {
   closeDb()
   process.chdir(cwdBefore)
+  if (previousHome === undefined) delete process.env.OPENRUN_HOME
+  else process.env.OPENRUN_HOME = previousHome
   rmSync(root, { recursive: true, force: true })
   for (const key of [
     'OPENRUN_CLAUDE_LIMITS',

--- a/src/server/workspaceHealth.test.ts
+++ b/src/server/workspaceHealth.test.ts
@@ -20,6 +20,8 @@ for (const cwd of [projectRepo, staleRepo]) {
 }
 
 const cwdBefore = process.cwd()
+const previousHome = process.env.OPENRUN_HOME
+process.env.OPENRUN_HOME = join(root, '.openrun')
 process.chdir(root)
 const vite = await createServer({
   root: appRoot,
@@ -39,6 +41,8 @@ after(async () => {
   closeDb()
   await vite.close()
   process.chdir(cwdBefore)
+  if (previousHome === undefined) delete process.env.OPENRUN_HOME
+  else process.env.OPENRUN_HOME = previousHome
   rmSync(root, { recursive: true, force: true })
 })
 


### PR DESCRIPTION
## Summary
- Runs, automations, and projects now live in `~/.openrun` with the rest of this machine's Open Run state, so a second clone or git worktree sees the same local data.
- A leftover `data/openrun.db` in a checkout is moved there on first boot, and a presets-only stub in home no longer hides a checkout that already has projects or runs.

## Test plan
- [ ] From a checkout that already has runs in `data/openrun.db`, start Open Run once and confirm `/runs` still lists them, and that `~/.openrun/openrun.db` exists while the checkout file is gone
- [ ] From a second worktree of the same repo, start Open Run on `:3000` only and confirm it shows the same runs without signing in or copying files
- [ ] Boot a throwaway `OPENRUN_HOME` and confirm a new install still creates `openrun.db` there, not under the checkout `data/` directory