### PR TITLE
docs: add concise pull request review skill

### DIFF
--- a/.agents/skills/fast-pr-review/SKILL.md
+++ b/.agents/skills/fast-pr-review/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: fast-pr-review
+description: Review pull requests for actionable defects and provide brief, natural developer comments. Use when asked to review a PR, diff, branch, or proposed code change.
+---
+
+# Fast PR Review
+
+Read the applicable repository instructions, the complete diff, and enough surrounding code to judge whether the change introduces a correctness, regression, security, compatibility, or repository-rule problem.
+
+Comment only when the author can take a useful action. Do not invent findings, summarize the change, restate code, narrate successful checks, or make obvious observations. Skip comments such as “TypeScript is OK,” “typecheck passes,” and “tests pass.”
+
+Write like a developer reviewing quickly:
+
+- Keep each comment to one or two short sentences.
+- State a defect and its consequence directly. Add a fix direction only when it helps.
+- Prefix a genuinely useful optional suggestion with `Nitpick:`.
+- Consolidate comments with the same root cause.
+- If there are no actionable findings, say only `Looks good to me.`
+
+Do not add headings, scorecards, a diff summary, or a verification summary. Do not post, approve, or otherwise mutate a pull request unless the user explicitly asks.

--- a/.agents/skills/fast-pr-review/agents/openai.yaml
+++ b/.agents/skills/fast-pr-review/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Fast PR Review"
+  short_description: "Write brief, actionable pull request comments"
+  default_prompt: "Review this pull request and return only brief, actionable comments."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -292,6 +292,13 @@ Closes #13
   here buries the steps a human must actually do. Tick a box only once you have
   performed it.
 
+**PR review comments are brief, natural, and useful.** Comment only on a specific
+actionable problem or a genuinely helpful optional improvement. Keep each comment
+to one or two short sentences; use `Nitpick: ...` for minor suggestions. Do not
+summarize the diff, restate the code, narrate checks, or post obvious observations
+such as "TypeScript is OK" or "tests pass." If there is nothing worth commenting
+on, say only `Looks good to me.`
+
 Reference shape: <https://github.com/dennisadriaans/openrun/pull/34>.
 
 The gates that used to live in the template are still hard rules, enforced in


### PR DESCRIPTION
## Summary
- Ship a repository-scoped skill for brief, actionable pull request reviews on every device
- Keep PR comments natural and limited to useful findings, nitpicks, or a short approval
- Exclude diff summaries, routine check results, and obvious observations from review comments

## Test plan
- [ ] Ask Codex to review a pull request and confirm it discovers `.agents/skills/fast-pr-review`
- [ ] Review a clean pull request and confirm the response is only `Looks good to me.`
- [ ] Review a pull request with a minor suggestion and confirm the comment is short and starts with `Nitpick:`