### PR TITLE
fix(release): publish bot-merged releases

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -110,3 +110,31 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           PR_URL: ${{ steps.pr.outputs.url }}
         run: gh pr merge "$PR_URL" --auto --squash
+
+      # A merge performed with GITHUB_TOKEN does not emit another workflow run,
+      # so the push trigger in release-publish.yml cannot observe this merge.
+      - name: Wait for release PR to merge
+        if: steps.release.outputs.prepared == 'true'
+        timeout-minutes: 20
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_URL: ${{ steps.pr.outputs.url }}
+        run: |
+          while true; do
+            merged_at=$(gh pr view "$PR_URL" --json mergedAt --jq '.mergedAt // ""')
+            state=$(gh pr view "$PR_URL" --json state --jq .state)
+            if [[ -n "$merged_at" ]]; then
+              break
+            fi
+            if [[ "$state" == "CLOSED" ]]; then
+              echo "Release PR closed without merging."
+              exit 1
+            fi
+            sleep 10
+          done
+
+      - name: Publish merged release
+        if: steps.release.outputs.prepared == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh workflow run release-publish.yml --ref main

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -124,7 +124,8 @@ Every step is safe to re-run.
 
 - `prepare` refuses if the tag already exists, and stops if the release branch is
   already open.
-- `publish` exits early if the tag exists, or if `HEAD` is not a release commit.
+- `publish` exits early if the tag exists, or if no matching release commit exists in
+  `HEAD`'s history. This lets a missed publish recover after later commits have landed.
   It never ships a second, different artifact under a version that already went out.
 - A failed publish is fixed by re-running the workflow, not by tagging by hand.
 

--- a/changelog.d/release-publish-dispatch.md
+++ b/changelog.d/release-publish-dispatch.md
@@ -1,0 +1,1 @@
+You no longer need to publish a prepared release manually after its automated pull request merges, or find a green publish job that skipped a squash commit carrying its pull request number.

--- a/scripts/release/conventional.test.ts
+++ b/scripts/release/conventional.test.ts
@@ -5,6 +5,7 @@ import {
   COMMIT_TYPE_NAMES,
   MAX_SUBJECT_LENGTH,
   commitBump,
+  isReleaseCommitSubject,
   parseCommit,
   typeMeta,
   validateCommitTitle,
@@ -34,6 +35,13 @@ test('a subject with no PR suffix keeps its full description', () => {
   const commit = at('docs: document the release pipeline')
   assert.equal(commit.description, 'document the release pipeline')
   assert.equal(commit.pr, null)
+})
+
+test('recognises release commits before and after squash merge', () => {
+  assert.equal(isReleaseCommitSubject('chore(release): v0.1.0', 'v0.1.0'), true)
+  assert.equal(isReleaseCommitSubject('chore(release): v0.1.0 (#63)', 'v0.1.0'), true)
+  assert.equal(isReleaseCommitSubject('chore(release): v0.1.1 (#64)', 'v0.1.0'), false)
+  assert.equal(isReleaseCommitSubject('fix(release): v0.1.0 (#63)', 'v0.1.0'), false)
 })
 
 test('detects a breaking change from the bang', () => {

--- a/scripts/release/conventional.ts
+++ b/scripts/release/conventional.ts
@@ -111,6 +111,12 @@ function stripPr(text: string): { text: string; pr: number | null } {
   return { text: text.slice(0, match.index).trim(), pr: Number(match[1]) }
 }
 
+/** Accepts the release commit before or after GitHub appends its squash PR number. */
+export function isReleaseCommitSubject(subject: string, tag: string): boolean {
+  const commit = parseCommit({ sha: '', subject })
+  return commit.type === 'chore' && commit.scope === 'release' && commit.description === tag
+}
+
 /** Metadata for a parsed commit's type, or null for an unknown/unconventional one. */
 export function typeMeta(commit: ParsedCommit): CommitTypeMeta | null {
   if (!commit.type) return null

--- a/scripts/release/index.ts
+++ b/scripts/release/index.ts
@@ -357,9 +357,12 @@ function commandPublish(argv: string[]): number {
     return 0
   }
 
-  const subject = git('log', '-1', '--format=%s')
-  if (!isReleaseCommitSubject(subject, tag)) {
-    console.log(`HEAD is "${subject}", not the release commit for ${tag} — nothing to publish.`)
+  const releaseCommit = gitQuiet('log', '--format=%H%x1f%s')
+    .split('\n')
+    .map((line) => line.split('\x1f'))
+    .find(([, subject = '']) => isReleaseCommitSubject(subject, tag))?.[0]
+  if (!releaseCommit) {
+    console.log(`No release commit for ${tag} exists in HEAD's history — nothing to publish.`)
     setOutput('published', 'false')
     return 0
   }
@@ -368,12 +371,12 @@ function commandPublish(argv: string[]): number {
   if (!notes) throw new ReleaseError(`CHANGELOG.md has no "## v${version}" section to publish.`)
 
   if (dryRun) {
-    console.log(`Would tag ${tag} at ${git('rev-parse', 'HEAD')} with:\n\n${notes}`)
+    console.log(`Would tag ${tag} at ${releaseCommit} with:\n\n${notes}`)
     setOutput('published', 'false')
     return 0
   }
 
-  git('tag', '-a', tag, '-m', `Open Run ${tag}`)
+  git('tag', '-a', tag, releaseCommit, '-m', `Open Run ${tag}`)
   git('push', 'origin', tag)
 
   const notesFile = join(ROOT, '.release-notes.md')

--- a/scripts/release/index.ts
+++ b/scripts/release/index.ts
@@ -23,6 +23,7 @@ import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 import { parseCadence, isReleaseDue } from './cadence.ts'
+import { isReleaseCommitSubject } from './conventional.ts'
 import { extractRelease, insertRelease, renderReleaseNotes, splitChangelog } from './notes.ts'
 import type { Fragment } from './notes.ts'
 import { planRelease, summariseCounts } from './plan.ts'
@@ -357,7 +358,7 @@ function commandPublish(argv: string[]): number {
   }
 
   const subject = git('log', '-1', '--format=%s')
-  if (subject !== `chore(release): ${tag}`) {
+  if (!isReleaseCommitSubject(subject, tag)) {
     console.log(`HEAD is "${subject}", not the release commit for ${tag} — nothing to publish.`)
     setOutput('published', 'false')
     return 0


### PR DESCRIPTION
## Summary

- Publish generated releases after their automated pull requests merge.
- Recognize GitHub squash commit subjects that include a pull request number.

## Test plan

- [ ] Merge this pull request and confirm Release · publish creates v0.1.0.
- [ ] Confirm a future generated release pull request dispatches publishing after auto-merge.