### PR TITLE
fix(release): configure tag author

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -29,6 +29,11 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
 
+      - name: Configure release author
+        run: |
+          git config user.name github-actions[bot]
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+
       - name: Verify release commit
         run: |
           pnpm exec biome ci src scripts

--- a/changelog.d/release-tag-author.md
+++ b/changelog.d/release-tag-author.md
@@ -1,0 +1,1 @@
+You no longer get a failed release because GitHub Actions lacked the identity required to create its annotated tag.


### PR DESCRIPTION
## Summary

- Configure the automated release identity before creating annotated tags.

## Test plan

- [ ] Merge this pull request and confirm Release · publish creates v0.1.0 at the PR #63 merge commit.
- [ ] Confirm the v0.1.0 GitHub Release is published with its generated notes.