### PR TITLE
fix(release): enforce one weekly release

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -1,16 +1,17 @@
 name: Release · prepare
 
 on:
-  # Run broadly enough that package.json owns the real cadence and timezone.
-  # Weekly/daily/manual can therefore change without editing this workflow.
+  # Retry hourly on Monday so a delayed/dropped 09:00 run does not skip the
+  # week. The cadence gate permits only the first successful release that day.
   schedule:
-    - cron: '0 * * * *'
+    - cron: '0 * * * 1'
+      timezone: Europe/Amsterdam
   workflow_dispatch:
     inputs:
       ignore_cadence:
         description: Prepare now, ignoring the configured cadence
         type: boolean
-        default: true
+        default: false
       allow_major:
         description: Allow an automatic major release at or above 1.0
         type: boolean
@@ -29,7 +30,7 @@ jobs:
   prepare:
     name: prepare release
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v7
         with:
@@ -47,6 +48,14 @@ jobs:
         run: |
           git config user.name github-actions[bot]
           git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+
+      # Repair a release PR that merged after an earlier prepare job timed out,
+      # or a tag whose GitHub Release creation failed partway through.
+      - name: Reconcile pending release
+        if: github.event_name == 'schedule'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: pnpm release:publish
 
       - name: Prepare
         id: release
@@ -68,8 +77,8 @@ jobs:
           BRANCH: ${{ steps.release.outputs.branch }}
         run: git push --force-with-lease origin "$BRANCH"
 
-      - name: Open release PR
-        if: steps.release.outputs.prepared == 'true'
+      - name: Open or resume release PR
+        if: steps.release.outputs.prepared != 'false'
         id: pr
         env:
           GH_TOKEN: ${{ github.token }}
@@ -77,6 +86,17 @@ jobs:
           TAG: ${{ steps.release.outputs.tag }}
           REASON: ${{ steps.release.outputs.reason }}
         run: |
+          url=$(gh pr list --head "$BRANCH" --state all --limit 1 --json url --jq '.[0].url // ""')
+          if [[ -n "$url" ]]; then
+            state=$(gh pr view "$url" --json state,mergedAt --jq 'if .mergedAt then "MERGED" else .state end')
+            if [[ "$state" == "CLOSED" ]]; then
+              gh pr reopen "$url"
+            fi
+            echo "url=$url" >> "$GITHUB_OUTPUT"
+            echo "merged=$([[ "$state" == "MERGED" ]] && echo true || echo false)" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
           {
             echo '## Summary'
             echo ''
@@ -94,18 +114,19 @@ jobs:
             --title "chore(release): $TAG" \
             --body-file /tmp/pr-body.md)
           echo "url=$url" >> "$GITHUB_OUTPUT"
+          echo "merged=false" >> "$GITHUB_OUTPUT"
 
       # A PR opened by GITHUB_TOKEN does not trigger pull_request workflows.
       # Run the same CI workflow explicitly on the release branch instead.
       - name: Run CI for release branch
-        if: steps.release.outputs.prepared == 'true'
+        if: steps.release.outputs.prepared != 'false' && steps.pr.outputs.merged != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           BRANCH: ${{ steps.release.outputs.branch }}
         run: gh workflow run ci.yml --ref "$BRANCH"
 
       - name: Enable auto-merge
-        if: steps.release.outputs.prepared == 'true'
+        if: steps.release.outputs.prepared != 'false' && steps.pr.outputs.merged != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           PR_URL: ${{ steps.pr.outputs.url }}
@@ -114,8 +135,9 @@ jobs:
       # A merge performed with GITHUB_TOKEN does not emit another workflow run,
       # so the push trigger in release-publish.yml cannot observe this merge.
       - name: Wait for release PR to merge
-        if: steps.release.outputs.prepared == 'true'
-        timeout-minutes: 20
+        if: steps.release.outputs.prepared != 'false'
+        id: merge
+        timeout-minutes: 45
         env:
           GH_TOKEN: ${{ github.token }}
           PR_URL: ${{ steps.pr.outputs.url }}
@@ -124,6 +146,8 @@ jobs:
             merged_at=$(gh pr view "$PR_URL" --json mergedAt --jq '.mergedAt // ""')
             state=$(gh pr view "$PR_URL" --json state --jq .state)
             if [[ -n "$merged_at" ]]; then
+              sha=$(gh pr view "$PR_URL" --json mergeCommit --jq '.mergeCommit.oid')
+              echo "sha=$sha" >> "$GITHUB_OUTPUT"
               break
             fi
             if [[ "$state" == "CLOSED" ]]; then
@@ -133,8 +157,19 @@ jobs:
             sleep 10
           done
 
-      - name: Publish merged release
-        if: steps.release.outputs.prepared == 'true'
+      - name: Publish and verify merged release
+        if: steps.release.outputs.prepared != 'false'
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh workflow run release-publish.yml --ref main
+          MERGE_SHA: ${{ steps.merge.outputs.sha }}
+          TAG: ${{ steps.release.outputs.tag }}
+        run: |
+          git fetch origin "$MERGE_SHA"
+          git checkout --detach "$MERGE_SHA"
+          pnpm release:publish -- --expect="$TAG"
+
+      - name: Remove release branch
+        if: steps.release.outputs.prepared != 'false'
+        env:
+          BRANCH: ${{ steps.release.outputs.branch }}
+        run: git push origin --delete "$BRANCH" || true

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -4,6 +4,11 @@ on:
   push:
     branches: [main]
   workflow_dispatch:
+    inputs:
+      expected_tag:
+        description: Fail unless this exact release is complete
+        type: string
+        required: false
 
 permissions:
   contents: write
@@ -41,7 +46,13 @@ jobs:
           pnpm test
           pnpm build
 
-      - name: Publish when HEAD is a release commit
+      - name: Reconcile release
         env:
           GH_TOKEN: ${{ github.token }}
-        run: pnpm release:publish
+          EXPECTED_TAG: ${{ inputs.expected_tag }}
+        run: |
+          args=()
+          if [[ -n "$EXPECTED_TAG" ]]; then
+            args+=(--expect="$EXPECTED_TAG")
+          fi
+          pnpm release:publish -- "${args[@]}"

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -103,10 +103,10 @@ release being cut rather than stranded above it.
 The schedule decides **when to ask** whether a release exists, never which
 version gets created. `cadence` is `weekly`, `daily` or `manual`.
 
-The workflow's own cron is deliberately wider than the window, and the window
-stays open for the rest of the release day — a cron delayed by twenty minutes
-must not skip a week. Running twice in one day is harmless: the second run sees
-the open `release/vX.Y.Z` branch and stops.
+The workflow retries hourly on Monday. The window opens at 09:00 Amsterdam time,
+and the newest tag records whether that Monday's release already happened. A
+delayed or dropped 09:00 run can therefore recover later that day, while later
+runs cannot prepare a second release in the same window.
 
 Changing the cadence is a one-line edit to `package.json`. Daylight saving is
 handled by the timezone, not by hand-converting the hour to UTC twice a year.
@@ -122,10 +122,11 @@ opens the same release PR the schedule would have; merging it publishes.
 
 Every step is safe to re-run.
 
-- `prepare` refuses if the tag already exists, and stops if the release branch is
-  already open.
-- `publish` exits early if the tag exists, or if no matching release commit exists in
-  `HEAD`'s history. This lets a missed publish recover after later commits have landed.
+- `prepare` resumes an existing release branch and pull request after a partial
+  failure instead of treating their existence as completion.
+- `publish` reconciles the tag and GitHub Release independently. It repairs a
+  missing Release after a tag push, verifies the tag target, and can recover a
+  missed publish after later commits have landed.
   It never ships a second, different artifact under a version that already went out.
 - A failed publish is fixed by re-running the workflow, not by tagging by hand.
 

--- a/changelog.d/solid-release-flow.md
+++ b/changelog.d/solid-release-flow.md
@@ -1,0 +1,1 @@
+You no longer get a second automatic release later on Monday, or a release pipeline that cannot recover after creating only its branch, pull request, tag, or GitHub Release.

--- a/scripts/release/cadence.test.ts
+++ b/scripts/release/cadence.test.ts
@@ -66,6 +66,26 @@ test('weekly stays due later in the day, so a late cron does not skip a week', (
   assert.equal(isReleaseDue(weekly, new Date('2026-08-31T15:00:00Z')).due, true)
 })
 
+test('weekly allows only one published release on its release day', () => {
+  const now = new Date('2026-08-31T15:00:00Z')
+  const released = new Date('2026-08-31T07:15:00Z')
+  const verdict = isReleaseDue(weekly, now, released)
+  assert.equal(verdict.due, false)
+  assert.match(verdict.reason, /already published/)
+})
+
+test('a release from the previous week does not block the next window', () => {
+  const now = new Date('2026-09-07T07:00:00Z')
+  const released = new Date('2026-08-31T07:15:00Z')
+  assert.equal(isReleaseDue(weekly, now, released).due, true)
+})
+
+test('the release day is compared in the configured timezone', () => {
+  const now = new Date('2026-08-31T15:00:00Z')
+  const justBeforeAmsterdamMonday = new Date('2026-08-30T21:59:00Z')
+  assert.equal(isReleaseDue(weekly, now, justBeforeAmsterdamMonday).due, true)
+})
+
 test('weekly is not due before the window opens', () => {
   const verdict = isReleaseDue(weekly, new Date('2026-08-31T05:00:00Z'))
   assert.equal(verdict.due, false)

--- a/scripts/release/cadence.ts
+++ b/scripts/release/cadence.ts
@@ -168,7 +168,11 @@ export type CadenceVerdict = {
  * missed-by-four-minutes window would skip a whole week. Running twice in one
  * day is harmless — `prepare` is idempotent on the version it computes.
  */
-export function isReleaseDue(config: CadenceConfig, now: Date = new Date()): CadenceVerdict {
+export function isReleaseDue(
+  config: CadenceConfig,
+  now: Date = new Date(),
+  lastReleasedAt: Date | null = null,
+): CadenceVerdict {
   const zoned = zonedNow(now, config.timezone)
   const clock = `${String(zoned.hour).padStart(2, '0')}:${String(zoned.minute).padStart(2, '0')}`
   const where = `${clock} ${config.timezone}, ${zoned.weekday}`
@@ -194,6 +198,14 @@ export function isReleaseDue(config: CadenceConfig, now: Date = new Date()): Cad
       due: false,
       date: zoned.date,
       reason: `Too early: the window opens at ${config.time} ${config.timezone}, and it is ${clock}.`,
+    }
+  }
+
+  if (lastReleasedAt && zonedNow(lastReleasedAt, config.timezone).date === zoned.date) {
+    return {
+      due: false,
+      date: zoned.date,
+      reason: `A release already published in the ${zoned.date} ${config.timezone} window.`,
     }
   }
 

--- a/scripts/release/index.ts
+++ b/scripts/release/index.ts
@@ -85,6 +85,25 @@ function tagExists(tag: string): boolean {
   return gitQuiet('tag', '--list', tag) === tag
 }
 
+function remoteTagTarget(tag: string): string | null {
+  const peeled = gitQuiet('ls-remote', '--tags', 'origin', `refs/tags/${tag}^{}`)
+  const direct = peeled || gitQuiet('ls-remote', '--tags', 'origin', `refs/tags/${tag}`)
+  return direct.split(/\s+/)[0] || null
+}
+
+function tagPublishedAt(tag: string | null): Date | null {
+  if (!tag) return null
+  const annotated = gitQuiet(
+    'for-each-ref',
+    '--format=%(taggerdate:iso-strict)',
+    `refs/tags/${tag}`,
+  )
+  const value = annotated || gitQuiet('log', '-1', '--format=%cI', tag)
+  if (!value) return null
+  const date = new Date(value)
+  return Number.isNaN(date.getTime()) ? null : date
+}
+
 /** Whether a branch already exists on `origin`, without needing it fetched. */
 function remoteBranchExists(branch: string): boolean {
   return gitQuiet('ls-remote', '--heads', 'origin', branch).includes(`refs/heads/${branch}`)
@@ -221,7 +240,12 @@ function commandPrepare(argv: string[]): number {
   // Cadence is checked before anything else so a non-release day costs one
   // `git` call and nothing more.
   if (argv.includes('--respect-cadence')) {
-    const verdict = isReleaseDue(parseCadence(readManifest().release))
+    const tag = latestTag()
+    const verdict = isReleaseDue(
+      parseCadence(readManifest().release),
+      new Date(),
+      tagPublishedAt(tag),
+    )
     if (!verdict.due) {
       console.log(verdict.reason)
       addSummary(`### No release\n\n${verdict.reason}`)
@@ -256,10 +280,13 @@ function commandPrepare(argv: string[]): number {
   // scheduled run would otherwise prepare the same version a second time.
   const branch = `release/${plan.tag}`
   if (remoteBranchExists(branch)) {
-    const message = `${branch} is already open — ${plan.tag} is prepared and waiting to merge.`
+    const message = `${branch} already exists — resuming preparation for ${plan.tag}.`
     console.log(message)
-    addSummary(`### No release\n\n${message}`)
-    setOutput('prepared', 'false')
+    addSummary(`### Resuming ${plan.tag}\n\n${message}`)
+    setOutput('prepared', 'existing')
+    setOutput('version', plan.next)
+    setOutput('tag', plan.tag)
+    setOutput('branch', branch)
     setOutput('reason', message)
     return 0
   }
@@ -347,14 +374,9 @@ function commandPublish(argv: string[]): number {
   if (!version) throw new ReleaseError('package.json has no "version" field.')
 
   const tag = toTag(version)
-
-  // Idempotency: publishing twice is a no-op, never a second artifact under
-  // the same version.
-  if (tagExists(tag)) {
-    console.log(`${tag} already exists — nothing to publish.`)
-    setOutput('published', 'false')
-    setOutput('tag', tag)
-    return 0
+  const expectedTag = argv.find((arg) => arg.startsWith('--expect='))?.slice('--expect='.length)
+  if (expectedTag && expectedTag !== tag) {
+    throw new ReleaseError(`Expected ${expectedTag}, but package.json identifies ${tag}.`)
   }
 
   const releaseCommit = gitQuiet('log', '--format=%H%x1f%s')
@@ -362,6 +384,8 @@ function commandPublish(argv: string[]): number {
     .map((line) => line.split('\x1f'))
     .find(([, subject = '']) => isReleaseCommitSubject(subject, tag))?.[0]
   if (!releaseCommit) {
+    if (expectedTag)
+      throw new ReleaseError(`No release commit for ${tag} exists in HEAD's history.`)
     console.log(`No release commit for ${tag} exists in HEAD's history — nothing to publish.`)
     setOutput('published', 'false')
     return 0
@@ -370,26 +394,68 @@ function commandPublish(argv: string[]): number {
   const notes = extractRelease(readFileSync(CHANGELOG, 'utf8'), version)
   if (!notes) throw new ReleaseError(`CHANGELOG.md has no "## v${version}" section to publish.`)
 
+  const existingTagTarget = remoteTagTarget(tag)
+  if (existingTagTarget) {
+    const target = existingTagTarget
+    if (target !== releaseCommit) {
+      throw new ReleaseError(
+        `${tag} points to ${target}, expected release commit ${releaseCommit}.`,
+      )
+    }
+  }
+
+  const releaseExists = Boolean(
+    run('gh', ['release', 'view', tag, '--json', 'tagName'], { allowFailure: true }),
+  )
+  if (existingTagTarget && releaseExists) {
+    console.log(`${tag} and its GitHub Release already exist at ${releaseCommit}.`)
+    setOutput('published', 'false')
+    setOutput('released', 'true')
+    setOutput('tag', tag)
+    setOutput('version', version)
+    return 0
+  }
+
   if (dryRun) {
     console.log(`Would tag ${tag} at ${releaseCommit} with:\n\n${notes}`)
     setOutput('published', 'false')
     return 0
   }
 
-  git('tag', '-a', tag, releaseCommit, '-m', `Open Run ${tag}`)
-  git('push', 'origin', tag)
+  if (!existingTagTarget) {
+    git('tag', '-f', '-a', tag, releaseCommit, '-m', `Open Run ${tag}`)
+    // Another publisher may win between the lookup and this push. Re-read the
+    // remote target below instead of turning that harmless race into a failure.
+    run('git', ['push', 'origin', tag], { allowFailure: true })
+    const target = remoteTagTarget(tag)
+    if (target !== releaseCommit) {
+      throw new ReleaseError(
+        target
+          ? `${tag} points to ${target}, expected release commit ${releaseCommit}.`
+          : `${tag} was not pushed to origin.`,
+      )
+    }
+  }
 
   const notesFile = join(ROOT, '.release-notes.md')
   writeFileSync(notesFile, notes)
   try {
-    run('gh', ['release', 'create', tag, '--title', `Open Run ${tag}`, '--notes-file', notesFile])
+    if (!releaseExists) {
+      run(
+        'gh',
+        ['release', 'create', tag, '--title', `Open Run ${tag}`, '--notes-file', notesFile],
+        { allowFailure: true },
+      )
+    }
   } finally {
     rmSync(notesFile, { force: true })
   }
 
-  console.log(`Published ${tag}.`)
+  run('gh', ['release', 'view', tag, '--json', 'tagName'])
+  console.log(`Published and verified ${tag} at ${releaseCommit}.`)
   addSummary(`### Published ${tag}\n\n${notes}`)
   setOutput('published', 'true')
+  setOutput('released', 'true')
   setOutput('tag', tag)
   setOutput('version', version)
   return 0
@@ -403,7 +469,7 @@ const USAGE = `Usage: pnpm release:<command>
   prepare  [--dry-run] [--skip-verify]          Write the release onto release/vX.Y.Z
            [--respect-cadence] [--allow-major]
            [--notes-from=both|fragments|unreleased]
-  publish  [--dry-run]                          Tag HEAD and create the GitHub Release
+  publish  [--dry-run] [--expect=vX.Y.Z]        Reconcile the tag and GitHub Release
 `
 
 function main(): number {


### PR DESCRIPTION
## Summary

- Allow only one automatic release in each Monday release window.
- Resume partially prepared releases and reconcile partial tag or GitHub Release creation.
- Retry safely when release publishing races or GitHub delays the scheduled run.

## Test plan

- [x] Confirm today's v0.1.0 blocks another cadence-respecting preparation.
- [x] Confirm publishing verifies the existing v0.1.0 tag and GitHub Release.
- [ ] Confirm the disabled schedule is re-enabled after this pull request merges.