### PR TITLE
fix(chat): render markdown tables correctly

### DIFF
--- a/changelog.d/user-message-markdown.md
+++ b/changelog.d/user-message-markdown.md
@@ -1,0 +1,3 @@
+You no longer see pasted Markdown tables, code fences, and emphasis as raw
+punctuation after submitting a message. Your prompts now render as Markdown in
+the conversation.

--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -514,7 +514,10 @@ const UserMessage = memo(function UserMessage({
             ))}
           </div>
         ) : null}
-        <div className={`chat-user__text ${long && !expanded ? 'line-clamp-6' : ''}`}>{text}</div>
+        <ChatMarkdown
+          text={text}
+          className={`chat-user__text ${long && !expanded ? 'line-clamp-6' : ''}`}
+        />
         {long ? (
           <button
             type="button"

--- a/src/styles.css
+++ b/src/styles.css
@@ -713,6 +713,13 @@ body {
   word-break: break-word;
 }
 
+.chat-user__text.chat-markdown {
+  font-family: var(--chat-user-font-family);
+  font-size: var(--chat-user-font-size);
+  line-height: var(--chat-user-leading);
+  color: var(--chat-user-color);
+}
+
 .chat-markdown > :first-child {
   margin-top: 0;
 }


### PR DESCRIPTION
## Summary
- Finalize the markdown-table rendering fix from #58 on the actual current `main` tree.
- Preserve all newer `main` changes while applying only the table-rendering fix.

## Test plan
- [ ] Open a chat response containing a Markdown table and confirm rows and columns render correctly.
- [ ] Confirm ordinary Markdown paragraphs, lists, links, and code blocks still render as before.