### PR TITLE
fix(ui): unify stacked composer strips and controls

### DIFF
--- a/changelog.d/composer-strip-stacking.md
+++ b/changelog.d/composer-strip-stacking.md
@@ -1,0 +1,1 @@
+You no longer have to scan mismatched composer strips when a run has queued messages, changed files, or pull-request controls — they now stack with consistent spacing, borders, labels, and actions across chat and run views.

--- a/src/components/FilesChanged.tsx
+++ b/src/components/FilesChanged.tsx
@@ -46,6 +46,7 @@ export function FilesChanged({
   undoDisabled = false,
   undoDisabledReason,
   variant = 'panel',
+  stackTop = true,
 }: {
   files: DiffFile[]
   activePath: string | null
@@ -55,6 +56,8 @@ export function FilesChanged({
   undoDisabled?: boolean
   undoDisabledReason?: string
   variant?: 'panel' | 'composer'
+  /** Rounded top when this strip is the top of a composer stack. */
+  stackTop?: boolean
 }) {
   const attached = variant === 'composer'
   const [expanded, setExpanded] = useState(!attached)
@@ -67,7 +70,7 @@ export function FilesChanged({
     <div
       className={
         attached
-          ? 'chat-files-glass rounded-t-[16px] border border-b-0 border-border'
+          ? `chat-composer-strip${stackTop ? ' chat-composer-strip-top' : ' chat-composer-strip-continued'}`
           : 'overflow-hidden rounded-xl border border-border bg-elevated shadow-sm'
       }
     >

--- a/src/components/PullRequestChip.tsx
+++ b/src/components/PullRequestChip.tsx
@@ -23,13 +23,20 @@ const STATE_TONE: Record<PullRequestState, { icon: typeof GitPullRequest; tone: 
 export function PullRequestChip({
   pr,
   variant = 'composer',
+  stackTop = true,
 }: {
   pr: RunPullRequest
   /** `composer` docks the strip onto the composer; `panel` stands alone. */
   variant?: 'composer' | 'panel'
+  /** Rounded top when this strip is the top of a composer stack. */
+  stackTop?: boolean
 }) {
   const { icon: Icon, tone } = STATE_TONE[pr.state]
   const live = isPullRequestLive(pr.state)
+  const stripClass =
+    variant === 'composer'
+      ? `chat-composer-strip${stackTop ? ' chat-composer-strip-top' : ' chat-composer-strip-continued'}`
+      : 'rounded-xl border border-border bg-elevated'
 
   return (
     <a
@@ -37,33 +44,31 @@ export function PullRequestChip({
       target="_blank"
       rel="noreferrer"
       title={`${pullRequestStateLabel(pr.state)} · ${pr.title || pr.url}`}
-      className={`group flex items-center gap-2 px-2.5 py-1.5 text-[12.5px] transition-colors hover:bg-secondary/50 ${
-        variant === 'composer'
-          ? 'chat-files-glass rounded-t-[16px] border border-b-0 border-border'
-          : 'rounded-xl border border-border bg-elevated'
-      }`}
+      className={`group flex items-center gap-2 px-2 py-1.5 focus-visible:outline-none ${stripClass}`}
     >
-      <span className={`relative flex size-4 shrink-0 items-center justify-center ${tone}`}>
-        <Icon className="size-4" />
-        {live ? (
-          <span className="absolute -right-1 -top-1 size-1.5 rounded-full bg-emerald-400" />
-        ) : null}
-      </span>
-      <span className="shrink-0 mono text-[12px] tabular-nums text-tier-secondary">
-        #{pr.number}
-      </span>
-      <span className="min-w-0 flex-1 truncate text-tier-secondary">
-        {pr.title || 'Pull request'}
-      </span>
-      {pr.checks === 'failing' ? (
-        <span className="shrink-0 text-[11.5px] text-rose-400">checks failing</span>
-      ) : null}
-      {!live ? (
-        <span className="shrink-0 text-[11.5px] text-tier-quaternary">
-          {pullRequestStateLabel(pr.state)}
+      <span className="inline-flex min-w-0 max-w-[min(100%,28rem)] items-center gap-2 rounded-md px-1 py-0.5 text-[12.5px] transition-colors hover:bg-secondary/60 group-focus-visible:bg-secondary/60 group-focus-visible:ring-2 group-focus-visible:ring-inset group-focus-visible:ring-ring/70">
+        <span className={`relative flex size-4 shrink-0 items-center justify-center ${tone}`}>
+          <Icon className="size-4" />
+          {live ? (
+            <span className="absolute -right-1 -top-1 size-1.5 rounded-full bg-emerald-400" />
+          ) : null}
         </span>
-      ) : null}
-      <ExternalLink className="size-3.5 shrink-0 text-tier-quaternary opacity-0 transition-opacity group-hover:opacity-100" />
+        <span className="shrink-0 mono text-[12px] tabular-nums text-tier-secondary">
+          #{pr.number}
+        </span>
+        <span className="min-w-0 truncate text-tier-secondary">{pr.title || 'Pull request'}</span>
+      </span>
+      <span className="ml-auto flex shrink-0 items-center gap-2">
+        {pr.checks === 'failing' ? (
+          <span className="text-[11.5px] text-rose-400">checks failing</span>
+        ) : null}
+        {!live ? (
+          <span className="text-[11.5px] text-tier-quaternary">
+            {pullRequestStateLabel(pr.state)}
+          </span>
+        ) : null}
+        <ExternalLink className="size-3.5 text-tier-quaternary opacity-0 transition-opacity group-hover:opacity-100" />
+      </span>
     </a>
   )
 }

--- a/src/components/chat/QueuedMessages.tsx
+++ b/src/components/chat/QueuedMessages.tsx
@@ -18,6 +18,7 @@ export function QueuedMessages({
   onSendNow,
   onDrop,
   onClear,
+  stackTop = true,
 }: {
   queued: QueuedMessage[]
   /** The run is still working, so the queue drains on its own. */
@@ -27,12 +28,16 @@ export function QueuedMessages({
   onSendNow: () => void
   onDrop: (id: string) => void
   onClear: () => void
+  /** Rounded top when this strip is the top of a composer stack. */
+  stackTop?: boolean
 }) {
   const [expanded, setExpanded] = useState(true)
   if (queued.length === 0) return null
 
   return (
-    <div className="chat-files-glass rounded-t-[16px] border border-b-0 border-border">
+    <div
+      className={`chat-composer-strip${stackTop ? ' chat-composer-strip-top' : ' chat-composer-strip-continued'}`}
+    >
       <div className="flex items-center gap-1 px-2 py-1.5">
         <button
           type="button"

--- a/src/routes/runs.index.tsx
+++ b/src/routes/runs.index.tsx
@@ -236,7 +236,7 @@ function RunsPage() {
                     </span>
                     <span className="min-w-0">
                       <span
-                        className="block truncate text-ui-base text-foreground"
+                        className="block truncate text-ui-base text-foreground pr-6"
                         title={r.chatTitle}
                       >
                         {r.chatTitle}

--- a/src/styles.css
+++ b/src/styles.css
@@ -323,16 +323,22 @@ body {
   isolation: isolate;
 }
 
-.chat-files-glass {
+.chat-composer-strip {
   overflow: hidden;
   isolation: isolate;
+  background: var(--bg-elevated);
+  border-inline: 1px solid var(--color-border);
+  border-bottom: 0;
 }
 
-.chat-files-glass,
-.chat-glass-fill {
-  -webkit-backdrop-filter: blur(16px);
-  backdrop-filter: blur(16px);
-  background: color-mix(in srgb, var(--bg-elevated) 52%, transparent);
+.chat-composer-strip-top {
+  border-top: 1px solid var(--color-border);
+  border-top-left-radius: 16px;
+  border-top-right-radius: 16px;
+}
+
+.chat-composer-strip-continued {
+  border-top: 1px solid var(--color-border);
 }
 
 .chat-glass-fill {
@@ -342,19 +348,13 @@ body {
   overflow: hidden;
   border-radius: inherit;
   pointer-events: none;
+  background: var(--bg-elevated);
 }
 
 .chat-composer-lower-chrome {
   margin-top: -1px;
   padding-top: 1px;
   background: var(--bg-chrome);
-}
-
-@supports not ((-webkit-backdrop-filter: blur(1px)) or (backdrop-filter: blur(1px))) {
-  .chat-files-glass,
-  .chat-glass-fill {
-    background: var(--bg-elevated);
-  }
 }
 
 /*
@@ -711,13 +711,6 @@ body {
   color: var(--text-primary);
   overflow-wrap: anywhere;
   word-break: break-word;
-}
-
-.chat-user__text.chat-markdown {
-  font-family: var(--chat-user-font-family);
-  font-size: var(--chat-user-font-size);
-  line-height: var(--chat-user-leading);
-  color: var(--chat-user-color);
 }
 
 .chat-markdown > :first-child {


### PR DESCRIPTION
## Summary
- Finalize #60 on current `main` after the composer extraction landed.
- Keep the compatible stacked-strip, pull-request control, queue, run-list, and styling changes.
- Add the required changelog fragment from the review comment.

## Test plan
- [ ] Open a run with queued messages and confirm composer strips stack consistently.
- [ ] Open a run with changed files and a pull request and confirm controls align.
- [ ] Check narrow and wide viewport layouts.