### PR TITLE
fix(mobile): validate pairing URLs

### DIFF
--- a/changelog.d/ios-pairing-openrun-url.md
+++ b/changelog.d/ios-pairing-openrun-url.md
@@ -1,3 +1,1 @@
-- The iOS pairing QR also accepts `openrun://pair?base=…&code=…` (the old
-  `agentops://` form still works). APNs env vars accept `OPENRUN_APNS_*` names
-  as well as `AGENTOPS_APNS_*`.
+You no longer need the legacy `agentops://` pairing scheme or `AGENTOPS_APNS_*` names: iOS pairing accepts validated `openrun://pair` URLs and APNs also reads `OPENRUN_APNS_*` settings.

--- a/src/lib/pairing.test.ts
+++ b/src/lib/pairing.test.ts
@@ -128,11 +128,19 @@ test('the agentops:// URL form decodes and normalizes the code', () => {
   assert.deepEqual(decoded, { base: 'http://192.168.1.24:3000', code: 'A1B2C3D4' })
 })
 
-test('the openrun:// URL form decodes the same way', () => {
+test('the openrun:// URL form decodes and validates the base', () => {
   const decoded = decodePairingQr(
-    'openrun://pair?base=http%3A%2F%2F192.168.1.24%3A3000&code=a1b2-c3d4',
+    'openrun://pair?base=http%3A%2F%2F192.168.1.24%3A3000%2Fignored&code=a1b2-c3d4',
   )
   assert.deepEqual(decoded, { base: 'http://192.168.1.24:3000', code: 'A1B2C3D4' })
+})
+
+test('pairing URL forms reject unexpected routes and invalid bases', () => {
+  assert.equal(
+    decodePairingQr('openrun://other?base=http%3A%2F%2F192.168.1.24%3A3000&code=a1b2-c3d4'),
+    null,
+  )
+  assert.equal(decodePairingQr('openrun://pair?base=http%3A%2F%2Fexample.com&code=a1b2-c3d4'), null)
 })
 
 test('garbage and partial QR payloads decode to null', () => {

--- a/src/lib/pairing.ts
+++ b/src/lib/pairing.ts
@@ -156,9 +156,13 @@ export function decodePairingQr(raw: string): PairingQrPayload | null {
   if (text.startsWith('agentops://') || text.startsWith('openrun://')) {
     try {
       const url = new URL(text)
+      if (url.hostname !== 'pair' || (url.pathname !== '' && url.pathname !== '/')) return null
       const base = url.searchParams.get('base')
       const code = url.searchParams.get('code')
-      if (base && code) return { base, code: normalizePairingCode(code) }
+      if (!base || !code) return null
+      const validated = validateBaseUrl(base)
+      if (!validated.ok) return null
+      return { base: validated.url, code: normalizePairingCode(code) }
     } catch {
       return null
     }


### PR DESCRIPTION
## Summary
- Finish the remaining review fixes from #49 after the base feature merged.
- Accept only the `openrun://pair` / legacy `agentops://pair` route and validate/canonicalize the embedded server base URL.
- Add regression coverage for unexpected routes and invalid public HTTP bases.
- Align the changelog fragment with the repository's established voice.

## Test plan
- [ ] Scan a valid `openrun://pair` QR and confirm pairing succeeds.
- [ ] Confirm non-pair routes and invalid bases are rejected.
- [ ] Run CI, including formatting, tests, and build.