### PR TITLE
feat(chat): finalize conversation navigation

### DIFF
--- a/changelog.d/thread-stack-navigation.md
+++ b/changelog.d/thread-stack-navigation.md
@@ -1,0 +1,1 @@
+You no longer have to return to run history to move between conversations or discover which background chat finished: the run header opens chats in the current worktree, and search reaches sibling worktrees and other projects. The project crumb reuses the same repository picker as a new chat, and jumps to that project's latest run.

--- a/src/components/chat/ThreadStack.tsx
+++ b/src/components/chat/ThreadStack.tsx
@@ -1,0 +1,211 @@
+import { useNavigate } from '@tanstack/react-router'
+import { ChevronDown, GitBranch, Search } from 'lucide-react'
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { relativeTime } from '../../lib/format'
+import { useConversationNavigationRuns } from '../../lib/conversationNavigation'
+import { adjacentThreadId, groupThreadLensRuns } from '../../lib/threadLens'
+import { truncateNavTitle } from '../../lib/truncateLabel.ts'
+import { ProviderIcon } from '../ProviderIcons'
+
+/** Change this default to `plain` to remove the wallet-card affordance only. */
+export const DEFAULT_THREAD_SELECTOR_APPEARANCE: 'stack' | 'plain' = 'stack'
+
+function runtimeKind(runtimeId: string, label: string) {
+  const value = `${runtimeId} ${label}`.toLocaleLowerCase()
+  if (value.includes('claude')) return 'claude'
+  if (value.includes('codex') || value.includes('openai')) return 'codex'
+  if (value.includes('grok')) return 'grok'
+  if (value.includes('antigravity')) return 'antigravity'
+  if (value.includes('fx')) return 'fx'
+  return value
+}
+
+export function ThreadStack({
+  runId,
+  title,
+  runtimeId,
+  runtimeLabel,
+  workspaceId,
+  projectId,
+  appearance = DEFAULT_THREAD_SELECTOR_APPEARANCE,
+}: {
+  runId: string
+  title: string
+  runtimeId: string
+  runtimeLabel: string
+  workspaceId: string
+  projectId: string
+  appearance?: 'stack' | 'plain'
+}) {
+  const { data: runs = [] } = useConversationNavigationRuns()
+  const [open, setOpen] = useState(false)
+  const [query, setQuery] = useState('')
+  const rootRef = useRef<HTMLDivElement>(null)
+  const inputRef = useRef<HTMLInputElement>(null)
+  const navigate = useNavigate()
+  const groups = useMemo(
+    () => groupThreadLensRuns(runs, { workspaceId, projectId }, query),
+    [projectId, query, runs, workspaceId],
+  )
+  const currentThreads = runs
+    .filter((run) => run.workspaceId === workspaceId)
+    .sort((a, b) => b.startedAt - a.startedAt)
+  const hasUnreadCurrentThread = currentThreads.some((run) => run.id !== runId && run.unread)
+
+  useEffect(() => {
+    if (!open) return
+    inputRef.current?.focus()
+    const close = (event: MouseEvent) => {
+      if (!rootRef.current?.contains(event.target as Node)) setOpen(false)
+    }
+    document.addEventListener('mousedown', close)
+    return () => document.removeEventListener('mousedown', close)
+  }, [open])
+
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if ((event.metaKey || event.ctrlKey) && event.key.toLocaleLowerCase() === 'k') {
+        event.preventDefault()
+        setOpen(true)
+        return
+      }
+      if (event.key === 'Escape') setOpen(false)
+      if (!(event.metaKey || event.ctrlKey) || !event.shiftKey) return
+      const direction = event.key === '[' ? -1 : event.key === ']' ? 1 : 0
+      if (!direction || currentThreads.length < 2) return
+      const nextId = adjacentThreadId(runs, workspaceId, runId, direction)
+      if (!nextId) return
+      event.preventDefault()
+      void navigate({ to: '/runs/$runId', params: { runId: nextId } })
+    }
+    document.addEventListener('keydown', onKeyDown)
+    return () => document.removeEventListener('keydown', onKeyDown)
+  }, [currentThreads.length, navigate, runId, runs, workspaceId])
+
+  const select = (id: string, newWindow = false) => {
+    setOpen(false)
+    setQuery('')
+    if (newWindow) {
+      window.open(`/runs/${encodeURIComponent(id)}`, '_blank', 'noopener,noreferrer')
+      return
+    }
+    void navigate({ to: '/runs/$runId', params: { runId: id } })
+  }
+
+  return (
+    <div ref={rootRef} className="relative min-w-0">
+      <div className="relative min-w-0">
+        {appearance === 'stack' && currentThreads.length > 1 ? (
+          <>
+            <span className="absolute inset-x-2 -top-1.5 h-4 rounded-md border border-border/40 bg-elevated/50" />
+            {currentThreads.length > 2 ? (
+              <span className="absolute inset-x-1 -top-0.5 h-4 rounded-md border border-border/60 bg-elevated/80" />
+            ) : null}
+          </>
+        ) : null}
+        <button
+          type="button"
+          aria-haspopup="dialog"
+          aria-expanded={open}
+          title={title}
+          onClick={() => setOpen((value) => !value)}
+          className={`relative flex w-full min-w-0 max-w-44 items-center gap-1 overflow-hidden rounded-md px-2 py-1 text-[13px] font-medium text-foreground transition-colors hover:bg-[var(--bg-luminous-quaternary)] sm:max-w-56 ${
+            open ? 'bg-secondary' : 'bg-background'
+          }`}
+        >
+          <ProviderIcon kind={runtimeKind(runtimeId, runtimeLabel)} className="size-3.5 shrink-0" />
+          <span className="min-w-0 flex-1 truncate">{truncateNavTitle(title)}</span>
+          {hasUnreadCurrentThread ? (
+            <span
+              role="img"
+              aria-label="New activity in another conversation"
+              title="New activity in another conversation"
+              className="size-1.5 shrink-0 rounded-full bg-accent"
+            />
+          ) : null}
+          <ChevronDown className="size-3 shrink-0 text-muted-foreground/60" aria-hidden="true" />
+        </button>
+      </div>
+
+      {open ? (
+        <div
+          role="dialog"
+          aria-label="Conversation context"
+          className="absolute left-0 top-full z-50 mt-2 w-[min(22rem,calc(100vw-2rem))] overflow-hidden rounded-2xl border border-border bg-elevated shadow-2xl shadow-black/40"
+        >
+          <div className="relative border-b border-border p-2.5">
+            <Search className="absolute left-5 top-1/2 size-3.5 -translate-y-1/2 text-muted-foreground" />
+            <input
+              ref={inputRef}
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+              placeholder="Search this worktree, or type to reach others…"
+              aria-label="Search conversations"
+              className="h-9 w-full rounded-lg border border-border bg-background pl-8 pr-12 text-sm text-foreground outline-none placeholder:text-muted-foreground focus:border-ring/50"
+            />
+            <kbd className="absolute right-5 top-1/2 -translate-y-1/2 text-[10px] text-muted-foreground">
+              ⌘K
+            </kbd>
+          </div>
+          <div className="max-h-[min(30rem,65vh)] overflow-y-auto p-2">
+            {groups.map((group) => (
+              <section key={group.key} className="not-first:mt-2">
+                {query.trim() || group.kind !== 'current' ? (
+                  <h3 className="flex items-center gap-1.5 px-2 py-1 text-[10px] font-medium uppercase tracking-[0.08em] text-muted-foreground">
+                    {group.kind === 'workspace' ? <GitBranch className="size-3" /> : null}
+                    {group.label}
+                    {group.runs.some((item) => item.unread) ? (
+                      <span
+                        aria-label="New activity in this worktree"
+                        title="New activity in this worktree"
+                        className="size-1.5 rounded-full bg-accent"
+                      />
+                    ) : null}
+                  </h3>
+                ) : null}
+                {group.runs.map((item) => (
+                  <button
+                    key={item.id}
+                    type="button"
+                    onClick={(event) => select(item.id, event.metaKey || event.ctrlKey)}
+                    className={`flex w-full items-center gap-2 rounded-lg px-2.5 py-2 text-left transition-colors hover:bg-secondary/70 ${
+                      item.id === runId ? 'bg-secondary text-foreground' : 'text-foreground/85'
+                    }`}
+                  >
+                    <ProviderIcon
+                      kind={runtimeKind(item.runtimeId, item.runtimeLabel)}
+                      className="size-3.5 shrink-0"
+                    />
+                    <span className="min-w-0 flex-1 truncate text-[13px]">{item.chatTitle}</span>
+                    {item.unread ? (
+                      <span
+                        role="img"
+                        aria-label="New activity"
+                        title="New activity"
+                        className="size-1.5 shrink-0 rounded-full bg-accent"
+                      />
+                    ) : null}
+                    <span
+                      className="max-w-[4.5rem] shrink-0 truncate text-[11px] text-muted-foreground"
+                      title={item.runtimeLabel}
+                    >
+                      {item.runtimeLabel}
+                    </span>
+                    <span className="w-10 shrink-0 text-right text-[11px] text-muted-foreground/70">
+                      {relativeTime(item.startedAt).replace(' ago', '')}
+                    </span>
+                  </button>
+                ))}
+              </section>
+            ))}
+            {groups.length === 0 ? (
+              <p className="px-3 py-8 text-center text-sm text-muted-foreground">
+                No conversations found
+              </p>
+            ) : null}
+          </div>
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/src/components/workspace/NavigationPicker.tsx
+++ b/src/components/workspace/NavigationPicker.tsx
@@ -1,0 +1,276 @@
+import { Check, ChevronDown, FolderGit2, GitBranch, Plus } from 'lucide-react'
+import { useEffect, useRef, useState, type ReactNode } from 'react'
+import { truncateBranchLabel, truncateNavTitle } from '../../lib/truncateLabel.ts'
+
+type NavigationMenuProps = {
+  label: string
+  title: string
+  icon: ReactNode
+  disabled?: boolean
+  muted?: boolean
+  trailing?: ReactNode
+  children: (close: () => void) => ReactNode
+}
+
+function NavigationMenu({
+  label,
+  title,
+  icon,
+  disabled,
+  muted,
+  trailing,
+  children,
+}: NavigationMenuProps) {
+  const [open, setOpen] = useState(false)
+  const rootRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (!open) return
+    const onPointer = (event: MouseEvent) => {
+      if (!rootRef.current?.contains(event.target as Node)) setOpen(false)
+    }
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') setOpen(false)
+    }
+    document.addEventListener('mousedown', onPointer)
+    document.addEventListener('keydown', onKey)
+    return () => {
+      document.removeEventListener('mousedown', onPointer)
+      document.removeEventListener('keydown', onKey)
+    }
+  }, [open])
+
+  return (
+    <div ref={rootRef} className="relative min-w-0">
+      <button
+        type="button"
+        disabled={disabled}
+        title={title}
+        aria-expanded={open}
+        aria-haspopup="menu"
+        onClick={() => setOpen((value) => !value)}
+        className={`flex w-full min-w-0 items-center gap-1 overflow-hidden rounded-md px-1 py-0.5 transition-colors hover:bg-[var(--bg-luminous-quaternary)] disabled:opacity-40 ${
+          muted ? 'text-muted-foreground' : 'font-medium text-foreground'
+        }`}
+      >
+        {icon}
+        <span className="min-w-0 flex-1 truncate">{label}</span>
+        {trailing}
+        <ChevronDown className="h-3 w-3 shrink-0 text-muted-foreground/60" aria-hidden="true" />
+      </button>
+      {open ? (
+        <div
+          role="menu"
+          className="absolute left-0 top-full z-50 mt-1.5 min-w-56 overflow-hidden rounded-xl border border-border bg-elevated p-1 shadow-xl shadow-black/40"
+        >
+          {children(() => setOpen(false))}
+        </div>
+      ) : null}
+    </div>
+  )
+}
+
+function NavigationItem({
+  label,
+  hint,
+  icon,
+  active,
+  disabled,
+  unread,
+  onSelect,
+}: {
+  label: string
+  hint?: string
+  icon: ReactNode
+  active?: boolean
+  disabled?: boolean
+  unread?: boolean
+  onSelect: () => void
+}) {
+  return (
+    <button
+      type="button"
+      role="menuitem"
+      disabled={disabled}
+      title={hint ?? label}
+      onClick={onSelect}
+      className={`flex w-full items-center gap-2 rounded-lg px-2.5 py-1.5 text-left transition-colors disabled:cursor-not-allowed disabled:opacity-50 ${
+        active ? 'bg-secondary text-foreground' : 'text-foreground/85 hover:bg-secondary/70'
+      }`}
+    >
+      {icon}
+      <span className="min-w-0 flex-1">
+        <span className="block truncate text-[12.5px] leading-tight">{label}</span>
+        {hint ? (
+          <span className="block truncate text-[10px] leading-tight text-muted-foreground">
+            {hint}
+          </span>
+        ) : null}
+      </span>
+      {unread ? (
+        <span
+          role="img"
+          aria-label="New activity"
+          className="size-1.5 shrink-0 rounded-full bg-accent"
+        />
+      ) : null}
+      {active ? <Check className="size-3.5 shrink-0" aria-hidden="true" /> : null}
+    </button>
+  )
+}
+
+export type NavigationProject = { id: string; name: string; path?: string; defaultBranch?: string }
+
+export function NavigationProjectPicker({
+  projects,
+  projectId,
+  disabled,
+  onChange,
+  onAddProject,
+}: {
+  projects: NavigationProject[]
+  projectId: string
+  disabled?: boolean
+  onChange: (id: string) => void
+  onAddProject?: () => void
+}) {
+  const selected = projects.find((project) => project.id === projectId)
+  return (
+    <NavigationMenu
+      label={truncateNavTitle(selected?.name ?? 'Select repository', 22)}
+      title={selected?.path ?? selected?.name ?? 'Select repository'}
+      icon={<FolderGit2 className="h-3.5 w-3.5 shrink-0 text-muted-foreground/60" />}
+      disabled={disabled}
+    >
+      {(close) => (
+        <>
+          {projects.map((project) => (
+            <NavigationItem
+              key={project.id}
+              label={project.name}
+              hint={project.defaultBranch ?? project.path}
+              icon={<FolderGit2 className="size-3.5 shrink-0 opacity-70" aria-hidden="true" />}
+              active={project.id === projectId}
+              onSelect={() => {
+                onChange(project.id)
+                close()
+              }}
+            />
+          ))}
+          {onAddProject ? (
+            <NavigationItem
+              label="Add project"
+              icon={<Plus className="size-3.5 shrink-0 opacity-70" aria-hidden="true" />}
+              onSelect={() => {
+                close()
+                onAddProject()
+              }}
+            />
+          ) : null}
+        </>
+      )}
+    </NavigationMenu>
+  )
+}
+
+export type NavigationWorkspace = {
+  id: string
+  branch: string
+  kind?: string
+}
+
+const PAGE_SIZE = 5
+
+export function NavigationWorkspacePicker({
+  workspaces,
+  workspaceId,
+  disabled,
+  muted,
+  busyId,
+  unreadIds,
+  onChange,
+  onRequestNewBranch,
+}: {
+  workspaces: NavigationWorkspace[]
+  workspaceId: string
+  disabled?: boolean
+  muted?: boolean
+  busyId?: string | null
+  unreadIds: ReadonlySet<string>
+  onChange: (id: string) => void
+  onRequestNewBranch?: () => void
+}) {
+  const [expanded, setExpanded] = useState(false)
+  const selected = workspaces.find((workspace) => workspace.id === workspaceId)
+  const visible = expanded ? workspaces : workspaces.slice(0, PAGE_SIZE)
+  return (
+    <NavigationMenu
+      label={truncateBranchLabel(selected?.branch ?? 'Select branch')}
+      title={selected?.branch ?? 'Select branch'}
+      icon={<GitBranch className="h-3.5 w-3.5 shrink-0 text-muted-foreground/60" />}
+      disabled={disabled}
+      muted={muted}
+      trailing={
+        <>
+          {selected && unreadIds.has(selected.id) ? (
+            <span
+              role="img"
+              aria-label="New activity in this worktree"
+              className="size-1.5 shrink-0 rounded-full bg-accent"
+            />
+          ) : null}
+          {selected?.kind === 'main' ? (
+            <span className="shrink-0 text-[11px] text-muted-foreground/50">(main)</span>
+          ) : null}
+        </>
+      }
+    >
+      {(close) => (
+        <>
+          <div className="px-2.5 py-1.5 text-[10px] uppercase tracking-wide text-muted-foreground">
+            Workspaces
+          </div>
+          {visible.map((workspace) => (
+            <NavigationItem
+              key={workspace.id}
+              label={workspace.branch}
+              hint={workspace.kind === 'main' ? 'main' : undefined}
+              icon={<GitBranch className="size-3.5 shrink-0 opacity-70" aria-hidden="true" />}
+              active={workspace.id === workspaceId}
+              disabled={busyId === workspace.id}
+              unread={unreadIds.has(workspace.id)}
+              onSelect={() => {
+                onChange(workspace.id)
+                close()
+              }}
+            />
+          ))}
+          {workspaces.length > PAGE_SIZE ? (
+            <button
+              type="button"
+              role="menuitem"
+              onClick={() => setExpanded((value) => !value)}
+              className="flex w-full items-center justify-center gap-1.5 rounded-lg px-2.5 py-2 text-[12px] text-muted-foreground transition-colors hover:bg-secondary/70 hover:text-foreground"
+            >
+              {expanded ? 'Show fewer' : 'More workspaces'}
+              <ChevronDown
+                className={`size-3.5 ${expanded ? 'rotate-180' : ''}`}
+                aria-hidden="true"
+              />
+            </button>
+          ) : null}
+          {onRequestNewBranch ? (
+            <NavigationItem
+              label="New branch…"
+              icon={<Plus className="size-3.5 shrink-0 opacity-70" aria-hidden="true" />}
+              onSelect={() => {
+                close()
+                onRequestNewBranch()
+              }}
+            />
+          ) : null}
+        </>
+      )}
+    </NavigationMenu>
+  )
+}

--- a/src/components/workspace/WorkspaceBreadcrumb.tsx
+++ b/src/components/workspace/WorkspaceBreadcrumb.tsx
@@ -7,32 +7,36 @@
  * switcher when workspaces are provided.
  */
 import { useNavigate } from '@tanstack/react-router'
-import { Check, ChevronDown, ChevronRight, GitBranch, Plus } from 'lucide-react'
-import { useRef, useState, type ReactNode } from 'react'
-import { useClickOutside } from '../../hooks/useClickOutside'
+import { ChevronRight, GitBranch } from 'lucide-react'
+import { useState, type ReactNode } from 'react'
 import type { WorkspaceWithMeta } from '../../fns'
-import { fetchLatestRunForWorkspace } from '../../lib/queries'
-
-const BRANCH_PAGE_SIZE = 5
+import { fetchLatestRunForWorkspace, useProjects } from '../../lib/queries'
+import {
+  fetchLatestRunForProject,
+  useConversationNavigationRuns,
+} from '../../lib/conversationNavigation'
+import { truncateBranchLabel } from '../../lib/truncateLabel.ts'
+import { threadNavigationIndex } from '../../lib/threadLens.ts'
+import {
+  NavigationProjectPicker,
+  NavigationWorkspacePicker,
+  type NavigationWorkspace,
+} from './NavigationPicker'
 
 function Separator() {
   return <ChevronRight className="h-3.5 w-3.5 shrink-0 text-muted-foreground/40" />
 }
 
-function Segment({
-  children,
-  className = '',
-  title,
-}: {
-  children: ReactNode
-  className?: string
-  title?: string
-}) {
+function Segment({ children, className = '', title }: { children: ReactNode; className?: string; title?: string }) {
   return (
     <span className={`min-w-0 truncate ${className}`} title={title}>
       {children}
     </span>
   )
+}
+
+function toNavigationWorkspace(ws: WorkspaceWithMeta): NavigationWorkspace {
+  return { id: ws.id, branch: ws.branch, kind: ws.kind }
 }
 
 function BranchSwitcher({
@@ -41,120 +45,61 @@ function BranchSwitcher({
   disabled,
   muted,
   onRequestNewBranch,
+  unreadWorkspaceIds,
+  latestRunIdByWorkspace,
+  onSelectWorkspace,
 }: {
-  current: WorkspaceWithMeta
+  current?: WorkspaceWithMeta | null
   workspaces: WorkspaceWithMeta[]
   disabled?: boolean
   muted?: boolean
   onRequestNewBranch?: () => void
+  unreadWorkspaceIds: ReadonlySet<string>
+  latestRunIdByWorkspace: ReadonlyMap<string, string>
+  onSelectWorkspace?: (workspaceId: string) => void
 }) {
-  const [open, setOpen] = useState(false)
   const [busyId, setBusyId] = useState<string | null>(null)
-  const [visibleCount, setVisibleCount] = useState(BRANCH_PAGE_SIZE)
-  const ref = useRef<HTMLDivElement>(null)
   const navigate = useNavigate()
-  const close = () => setOpen(false)
-  useClickOutside(open, close, [ref])
+  const ready = workspaces.filter((w) => w.status === 'ready' || w.id === current?.id)
 
-  const ready = workspaces.filter((w) => w.status === 'ready' || w.id === current.id)
-  const visibleWorkspaces = ready.slice(0, visibleCount)
-  const hasMore = visibleWorkspaces.length < ready.length
-
-  const switchTo = async (ws: WorkspaceWithMeta) => {
-    if (ws.id === current.id) {
-      setOpen(false)
+  const switchTo = async (id: string) => {
+    if (id === current?.id) return
+    if (onSelectWorkspace) {
+      onSelectWorkspace(id)
       return
     }
+    const ws = workspaces.find((row) => row.id === id)
+    if (!ws) return
     setBusyId(ws.id)
     try {
-      const latest = await fetchLatestRunForWorkspace(ws.id)
-      if (latest?.id) {
-        navigate({ to: '/runs/$runId', params: { runId: latest.id } })
+      const cachedId = latestRunIdByWorkspace.get(ws.id)
+      const latestId = cachedId ?? (await fetchLatestRunForWorkspace(ws.id))?.id
+      if (latestId) {
+        navigate({ to: '/runs/$runId', params: { runId: latestId } })
       } else {
-        navigate({ to: '/runs' })
+        navigate({ to: '/runs/new', search: { projectId: ws.projectId, workspaceId: ws.id } })
       }
-      setOpen(false)
     } finally {
       setBusyId(null)
     }
   }
 
   return (
-    <div ref={ref} className="relative min-w-0 max-w-[36%] shrink">
-      <button
-        type="button"
-        disabled={disabled}
-        onClick={() => {
-          if (!open) setVisibleCount(BRANCH_PAGE_SIZE)
-          setOpen((v) => !v)
-        }}
-        title={current.path}
-        className={`flex min-w-0 max-w-full items-center gap-1.5 rounded-md px-1 py-0.5 transition-colors hover:bg-[var(--bg-luminous-quaternary)] disabled:opacity-40 ${
-          muted ? 'text-muted-foreground' : 'font-medium text-foreground'
-        }`}
-      >
-        <GitBranch className="h-3.5 w-3.5 shrink-0 text-muted-foreground/60" />
-        <span className="mono min-w-0 truncate">{current.branch}</span>
-        {current.kind === 'main' ? (
-          <span className="shrink-0 text-[11px] text-muted-foreground/50">(main)</span>
-        ) : null}
-        <ChevronDown className="h-3 w-3 shrink-0 text-muted-foreground/60" />
-      </button>
-
-      {open ? (
-        <div className="absolute left-0 top-full z-40 mt-1.5 min-w-56 overflow-hidden rounded-xl border border-border bg-elevated p-1 shadow-xl shadow-black/40">
-          <div className="px-2.5 py-1.5 text-[10px] uppercase tracking-wide text-muted-foreground">
-            Workspaces
-          </div>
-          {visibleWorkspaces.map((ws) => (
-            <button
-              key={ws.id}
-              type="button"
-              disabled={busyId === ws.id}
-              onClick={() => void switchTo(ws)}
-              className={`flex w-full items-center gap-2 rounded-lg px-2.5 py-2 text-left text-sm transition-colors ${
-                ws.id === current.id
-                  ? 'bg-secondary text-foreground'
-                  : 'text-foreground/85 hover:bg-secondary/70'
-              }`}
-            >
-              <GitBranch className="size-3.5 shrink-0 opacity-70" />
-              <span className="min-w-0 flex-1 truncate mono text-[12.5px]">{ws.branch}</span>
-              {ws.kind === 'main' ? (
-                <span className="text-[10px] text-muted-foreground">main</span>
-              ) : null}
-              {ws.id === current.id ? <Check className="size-3.5 shrink-0" /> : null}
-            </button>
-          ))}
-          {hasMore ? (
-            <button
-              type="button"
-              onClick={() => setVisibleCount((count) => count + BRANCH_PAGE_SIZE)}
-              className="flex w-full items-center justify-center rounded-lg px-2.5 py-2 text-[12px] text-muted-foreground transition-colors hover:bg-secondary/70 hover:text-foreground"
-            >
-              Load more
-            </button>
-          ) : null}
-          {onRequestNewBranch ? (
-            <button
-              type="button"
-              onClick={() => {
-                setOpen(false)
-                onRequestNewBranch()
-              }}
-              className="mt-0.5 flex w-full items-center gap-2 rounded-lg border-t border-border px-2.5 py-2 text-left text-sm text-foreground/85 hover:bg-secondary/70"
-            >
-              <Plus className="size-3.5 shrink-0 opacity-70" />
-              New branch…
-            </button>
-          ) : null}
-        </div>
-      ) : null}
-    </div>
+    <NavigationWorkspacePicker
+      workspaces={ready.map(toNavigationWorkspace)}
+      workspaceId={current?.id ?? ''}
+      disabled={disabled}
+      muted={muted}
+      busyId={busyId}
+      unreadIds={unreadWorkspaceIds}
+      onChange={(id) => void switchTo(id)}
+      onRequestNewBranch={onRequestNewBranch}
+    />
   )
 }
 
 export function WorkspaceBreadcrumb({
+  projectId,
   projectName,
   branch,
   isMainCheckout,
@@ -164,7 +109,11 @@ export function WorkspaceBreadcrumb({
   workspaces,
   branchDisabled,
   onRequestNewBranch,
+  onAddProject,
+  onSelectProject,
+  onSelectWorkspace,
 }: {
+  projectId?: string
   projectName?: string
   branch?: string
   isMainCheckout?: boolean
@@ -174,48 +123,84 @@ export function WorkspaceBreadcrumb({
   workspaces?: WorkspaceWithMeta[]
   branchDisabled?: boolean
   onRequestNewBranch?: () => void
+  onAddProject?: () => void
+  onSelectProject?: (projectId: string) => void
+  onSelectWorkspace?: (workspaceId: string) => void
 }) {
-  const showSwitcher = Boolean(workspace && workspaces)
+  const navigate = useNavigate()
+  const { data: projects = [] } = useProjects()
+  const { data: runs = [] } = useConversationNavigationRuns()
+  const { unreadWorkspaceIds, latestRunIdByWorkspace, latestRunIdByProject } = threadNavigationIndex(runs)
+  const showSwitcher = workspaces !== undefined
   const branchLabel = workspace?.branch ?? branch
+  const currentProjectId = projectId ?? workspace?.projectId ?? ''
+  const pickerProjects =
+    currentProjectId && projectName && !projects.some((row) => row.id === currentProjectId)
+      ? [{ id: currentProjectId, name: projectName }, ...projects]
+      : projects
+
+  const switchProject = async (nextId: string) => {
+    if (!nextId || nextId === currentProjectId) return
+    if (onSelectProject) {
+      onSelectProject(nextId)
+      return
+    }
+    const cachedId = latestRunIdByProject.get(nextId)
+    const latestId = cachedId ?? (await fetchLatestRunForProject(nextId))?.id
+    if (latestId) {
+      navigate({ to: '/runs/$runId', params: { runId: latestId } })
+      return
+    }
+    navigate({ to: '/runs/new', search: { projectId: nextId } })
+  }
 
   return (
     <nav aria-label="Breadcrumb" className="flex min-w-0 flex-1 items-center gap-1.5 text-[13px]">
-      {projectName ? (
+      {currentProjectId && (projects.length > 0 || projectName) ? (
         <>
-          <span
-            className="min-w-0 max-w-[30%] shrink truncate text-muted-foreground"
-            title={projectName}
-          >
+          <NavigationProjectPicker
+            projects={pickerProjects}
+            projectId={currentProjectId}
+            disabled={branchDisabled}
+            onChange={(id) => void switchProject(id)}
+            onAddProject={onAddProject}
+          />
+          {branchLabel || showSwitcher || runTitle || trailing ? <Separator /> : null}
+        </>
+      ) : projectName ? (
+        <>
+          <span className="min-w-0 max-w-[30%] shrink truncate text-muted-foreground" title={projectName}>
             {projectName}
           </span>
-          {branchLabel || runTitle ? <Separator /> : null}
+          {branchLabel || showSwitcher || runTitle || trailing ? <Separator /> : null}
         </>
       ) : null}
 
-      {showSwitcher && workspace && workspaces ? (
+      {showSwitcher ? (
         <>
           <BranchSwitcher
             current={workspace}
-            workspaces={workspaces}
+            workspaces={workspaces ?? []}
             disabled={branchDisabled}
             muted={Boolean(runTitle)}
             onRequestNewBranch={onRequestNewBranch}
+            unreadWorkspaceIds={unreadWorkspaceIds}
+            latestRunIdByWorkspace={latestRunIdByWorkspace}
+            onSelectWorkspace={onSelectWorkspace}
           />
           {runTitle ? <Separator /> : null}
         </>
       ) : branchLabel ? (
         <>
           <Segment
-            className={`flex max-w-[36%] shrink items-center gap-1.5 ${
+            className={`flex max-w-44 shrink items-center gap-1.5 sm:max-w-52 ${
               runTitle ? 'text-muted-foreground' : 'font-medium text-foreground'
             }`}
             title={branchLabel}
           >
             <GitBranch className="h-3.5 w-3.5 shrink-0 text-muted-foreground/60" />
-            <span className="mono min-w-0 truncate">{branchLabel}</span>
-            {isMainCheckout ? (
-              <span className="shrink-0 text-[11px] text-muted-foreground/50">(main)</span>
-            ) : null}
+            <span className="mono min-w-0 truncate">{truncateBranchLabel(branchLabel)}</span>
+            {isMainCheckout ? <span className="shrink-0 text-[11px] text-muted-foreground/50">(main)</span> : null}
           </Segment>
           {runTitle ? <Separator /> : null}
         </>
@@ -227,7 +212,12 @@ export function WorkspaceBreadcrumb({
         </Segment>
       ) : null}
 
-      {trailing ? <span className="shrink-0">{trailing}</span> : null}
+      {trailing ? (
+        <>
+          <Separator />
+          <span className="min-w-0 shrink">{trailing}</span>
+        </>
+      ) : null}
     </nav>
   )
 }

--- a/src/components/workspace/WorkspaceBreadcrumb.tsx
+++ b/src/components/workspace/WorkspaceBreadcrumb.tsx
@@ -27,7 +27,15 @@ function Separator() {
   return <ChevronRight className="h-3.5 w-3.5 shrink-0 text-muted-foreground/40" />
 }
 
-function Segment({ children, className = '', title }: { children: ReactNode; className?: string; title?: string }) {
+function Segment({
+  children,
+  className = '',
+  title,
+}: {
+  children: ReactNode
+  className?: string
+  title?: string
+}) {
   return (
     <span className={`min-w-0 truncate ${className}`} title={title}>
       {children}
@@ -130,7 +138,8 @@ export function WorkspaceBreadcrumb({
   const navigate = useNavigate()
   const { data: projects = [] } = useProjects()
   const { data: runs = [] } = useConversationNavigationRuns()
-  const { unreadWorkspaceIds, latestRunIdByWorkspace, latestRunIdByProject } = threadNavigationIndex(runs)
+  const { unreadWorkspaceIds, latestRunIdByWorkspace, latestRunIdByProject } =
+    threadNavigationIndex(runs)
   const showSwitcher = workspaces !== undefined
   const branchLabel = workspace?.branch ?? branch
   const currentProjectId = projectId ?? workspace?.projectId ?? ''
@@ -169,7 +178,10 @@ export function WorkspaceBreadcrumb({
         </>
       ) : projectName ? (
         <>
-          <span className="min-w-0 max-w-[30%] shrink truncate text-muted-foreground" title={projectName}>
+          <span
+            className="min-w-0 max-w-[30%] shrink truncate text-muted-foreground"
+            title={projectName}
+          >
             {projectName}
           </span>
           {branchLabel || showSwitcher || runTitle || trailing ? <Separator /> : null}
@@ -200,7 +212,9 @@ export function WorkspaceBreadcrumb({
           >
             <GitBranch className="h-3.5 w-3.5 shrink-0 text-muted-foreground/60" />
             <span className="mono min-w-0 truncate">{truncateBranchLabel(branchLabel)}</span>
-            {isMainCheckout ? <span className="shrink-0 text-[11px] text-muted-foreground/50">(main)</span> : null}
+            {isMainCheckout ? (
+              <span className="shrink-0 text-[11px] text-muted-foreground/50">(main)</span>
+            ) : null}
           </Segment>
           {runTitle ? <Separator /> : null}
         </>

--- a/src/fns/conversationNavigation.ts
+++ b/src/fns/conversationNavigation.ts
@@ -1,0 +1,11 @@
+import { createServerFn } from '@tanstack/react-start'
+
+export const listConversationNavigationRuns = createServerFn({ method: 'GET' }).handler(async () =>
+  (await import('../server/conversationNavigation')).listConversationNavigationRuns(),
+)
+
+export const getLatestRunForProject = createServerFn({ method: 'GET' })
+  .validator((d: { projectId: string }) => d)
+  .handler(async ({ data }) =>
+    (await import('../server/conversationNavigation')).getLatestRunForProject(data.projectId),
+  )

--- a/src/lib/conversationNavigation.ts
+++ b/src/lib/conversationNavigation.ts
@@ -1,0 +1,16 @@
+import { useQuery } from '@tanstack/react-query'
+import {
+  getLatestRunForProject,
+  listConversationNavigationRuns,
+} from '../fns/conversationNavigation'
+
+export function useConversationNavigationRuns() {
+  return useQuery({
+    queryKey: ['runs', 'conversation-navigation'],
+    queryFn: () => listConversationNavigationRuns(),
+  })
+}
+
+export async function fetchLatestRunForProject(projectId: string) {
+  return getLatestRunForProject({ data: { projectId } })
+}

--- a/src/lib/threadLens.test.ts
+++ b/src/lib/threadLens.test.ts
@@ -1,0 +1,105 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+import {
+  adjacentThreadId,
+  groupThreadLensRuns,
+  threadNavigationIndex,
+  type ThreadLensRun,
+} from './threadLens.ts'
+
+const run = (
+  id: string,
+  workspaceId: string,
+  projectId: string,
+  startedAt: number,
+): ThreadLensRun => ({
+  id,
+  workspaceId,
+  projectId,
+  startedAt,
+  chatTitle: `Thread ${id}`,
+  runtimeLabel: id === 'one' ? 'Codex' : 'Claude',
+  runtimeId: id === 'one' ? 'codex' : 'claude',
+  workspaceBranch: workspaceId,
+  projectName: projectId,
+  unread: false,
+})
+
+describe('groupThreadLensRuns', () => {
+  it('lists only the current worktree until you search', () => {
+    const groups = groupThreadLensRuns(
+      [
+        run('other', 'ws-c', 'project-b', 4),
+        run('sibling', 'ws-b', 'project-a', 3),
+        run('one', 'ws-a', 'project-a', 2),
+      ],
+      { workspaceId: 'ws-a', projectId: 'project-a' },
+    )
+    assert.deepEqual(
+      groups.map((group) => group.kind),
+      ['current'],
+    )
+    assert.deepEqual(
+      groups[0]?.runs.map((item) => item.id),
+      ['one'],
+    )
+  })
+
+  it('reaches sibling worktrees and other projects when searching', () => {
+    const groups = groupThreadLensRuns(
+      [
+        run('other', 'ws-c', 'project-b', 4),
+        run('sibling', 'ws-b', 'project-a', 3),
+        run('one', 'ws-a', 'project-a', 2),
+      ],
+      { workspaceId: 'ws-a', projectId: 'project-a' },
+      'thread',
+    )
+    assert.deepEqual(
+      groups.map((group) => group.kind),
+      ['current', 'workspace', 'project'],
+    )
+    assert.equal(groups[0]?.runs[0]?.id, 'one')
+  })
+
+  it('searches titles, agents, worktrees, and projects', () => {
+    const groups = groupThreadLensRuns(
+      [run('one', 'main', 'open-run', 2), run('two', 'release', 'dashboard', 1)],
+      { workspaceId: 'main', projectId: 'open-run' },
+      'claude',
+    )
+    assert.deepEqual(
+      groups.flatMap((group) => group.runs.map((item) => item.id)),
+      ['two'],
+    )
+  })
+
+  it('does not impose the old 200-conversation navigation boundary', () => {
+    const runs = Array.from({ length: 250 }, (_, index) =>
+      run(`run-${index}`, 'ws-a', 'project-a', index),
+    )
+    const groups = groupThreadLensRuns(runs, { workspaceId: 'ws-a', projectId: 'project-a' })
+    assert.equal(groups[0]?.runs.length, 250)
+    assert.equal(groups[0]?.runs[0]?.id, 'run-249')
+  })
+})
+
+describe('thread navigation', () => {
+  it('indexes the latest run and unread state independent of input order', () => {
+    const older = run('older', 'ws-a', 'project-a', 1)
+    older.unread = true
+    const latest = run('latest', 'ws-a', 'project-a', 3)
+    const other = run('other', 'ws-b', 'project-a', 2)
+    const index = threadNavigationIndex([older, latest, other])
+    assert.equal(index.latestRunIdByWorkspace.get('ws-a'), 'latest')
+    assert.equal(index.latestRunIdByProject.get('project-a'), 'latest')
+    assert.equal(index.unreadWorkspaceIds.has('ws-a'), true)
+  })
+
+  it('cycles within the current worktree and refuses a missing current run', () => {
+    const runs = [run('latest', 'ws-a', 'project-a', 3), run('older', 'ws-a', 'project-a', 1)]
+    assert.equal(adjacentThreadId(runs, 'ws-a', 'latest', 1), 'older')
+    assert.equal(adjacentThreadId(runs, 'ws-a', 'latest', -1), 'older')
+    assert.equal(adjacentThreadId(runs, 'ws-a', 'missing', 1), null)
+  })
+})

--- a/src/lib/threadLens.ts
+++ b/src/lib/threadLens.ts
@@ -1,0 +1,119 @@
+export type ThreadLensRun = {
+  id: string
+  chatTitle: string
+  runtimeLabel: string
+  runtimeId: string
+  startedAt: number
+  workspaceId: string
+  workspaceBranch: string
+  projectId: string
+  projectName: string
+  unread: boolean
+}
+
+export type ThreadLensGroup = {
+  key: string
+  label: string
+  kind: 'current' | 'workspace' | 'project'
+  runs: ThreadLensRun[]
+}
+
+export function threadNavigationIndex(runs: ThreadLensRun[]): {
+  unreadWorkspaceIds: Set<string>
+  latestRunIdByWorkspace: Map<string, string>
+  latestRunIdByProject: Map<string, string>
+} {
+  const unreadWorkspaceIds = new Set<string>()
+  const latestRunIdByWorkspace = new Map<string, string>()
+  const latestRunIdByProject = new Map<string, string>()
+  for (const run of [...runs].sort((a, b) => b.startedAt - a.startedAt)) {
+    if (run.unread && run.workspaceId) unreadWorkspaceIds.add(run.workspaceId)
+    if (run.workspaceId && !latestRunIdByWorkspace.has(run.workspaceId)) {
+      latestRunIdByWorkspace.set(run.workspaceId, run.id)
+    }
+    if (run.projectId && !latestRunIdByProject.has(run.projectId)) {
+      latestRunIdByProject.set(run.projectId, run.id)
+    }
+  }
+  return { unreadWorkspaceIds, latestRunIdByWorkspace, latestRunIdByProject }
+}
+
+export function adjacentThreadId(
+  runs: ThreadLensRun[],
+  workspaceId: string,
+  runId: string,
+  direction: -1 | 1,
+): string | null {
+  const threads = runs
+    .filter((run) => run.workspaceId === workspaceId)
+    .sort((a, b) => b.startedAt - a.startedAt)
+  if (threads.length < 2) return null
+  const index = threads.findIndex((run) => run.id === runId)
+  if (index < 0) return null
+  return threads[(index + direction + threads.length) % threads.length]?.id ?? null
+}
+
+/**
+ * Conversations for the header picker. An empty query is this worktree only;
+ * a search reaches sibling worktrees and other projects.
+ */
+export function groupThreadLensRuns(
+  runs: ThreadLensRun[],
+  current: { workspaceId: string; projectId: string },
+  query = '',
+): ThreadLensGroup[] {
+  const needle = query.trim().toLocaleLowerCase()
+  const scoped = needle ? runs : runs.filter((run) => run.workspaceId === current.workspaceId)
+  const matching = needle
+    ? scoped.filter((run) =>
+        [run.chatTitle, run.runtimeLabel, run.workspaceBranch, run.projectName].some((value) =>
+          value.toLocaleLowerCase().includes(needle),
+        ),
+      )
+    : scoped
+  const sorted = [...matching].sort((a, b) => b.startedAt - a.startedAt)
+  const groups: ThreadLensGroup[] = []
+  const add = (group: ThreadLensGroup) => {
+    if (group.runs.length > 0) groups.push(group)
+  }
+
+  add({
+    key: `workspace:${current.workspaceId}`,
+    label: 'Current worktree',
+    kind: 'current',
+    runs: sorted.filter((run) => run.workspaceId === current.workspaceId),
+  })
+
+  const siblingBranches = new Map<string, ThreadLensRun[]>()
+  for (const run of sorted) {
+    if (run.projectId !== current.projectId || run.workspaceId === current.workspaceId) continue
+    const group = siblingBranches.get(run.workspaceId) ?? []
+    group.push(run)
+    siblingBranches.set(run.workspaceId, group)
+  }
+  for (const [workspaceId, workspaceRuns] of siblingBranches) {
+    add({
+      key: `workspace:${workspaceId}`,
+      label: workspaceRuns[0]?.workspaceBranch || 'Other worktree',
+      kind: 'workspace',
+      runs: workspaceRuns,
+    })
+  }
+
+  const projects = new Map<string, ThreadLensRun[]>()
+  for (const run of sorted) {
+    if (!run.projectId || run.projectId === current.projectId) continue
+    const group = projects.get(run.projectId) ?? []
+    group.push(run)
+    projects.set(run.projectId, group)
+  }
+  for (const [projectId, projectRuns] of projects) {
+    add({
+      key: `project:${projectId}`,
+      label: projectRuns[0]?.projectName || 'Other project',
+      kind: 'project',
+      runs: projectRuns,
+    })
+  }
+  return groups
+}

--- a/src/lib/truncateLabel.test.ts
+++ b/src/lib/truncateLabel.test.ts
@@ -1,0 +1,45 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+import {
+  truncateBranchLabel,
+  truncateEnd,
+  truncateMiddle,
+  truncateNavTitle,
+} from './truncateLabel.ts'
+
+describe('truncateMiddle', () => {
+  it('returns short strings unchanged', () => {
+    assert.equal(truncateMiddle('main', 20), 'main')
+  })
+
+  it('keeps both ends', () => {
+    assert.equal(truncateMiddle('organize-chat-navigation', 18), 'organize-…vigation')
+  })
+})
+
+describe('truncateEnd', () => {
+  it('collapses whitespace and clips on a word boundary slice', () => {
+    assert.equal(truncateEnd('hello   world', 8), 'hello w…')
+  })
+})
+
+describe('truncateBranchLabel', () => {
+  it('keeps the branch prefix', () => {
+    assert.equal(
+      truncateBranchLabel('feature/organize-chat-navigation', 26),
+      'feature/organize-…vigation',
+    )
+  })
+
+  it('falls back to middle truncation without a slash', () => {
+    assert.equal(truncateBranchLabel('very-long-branch-name-here', 20), 'very-long-…name-here')
+  })
+})
+
+describe('truncateNavTitle', () => {
+  it('clips long chat titles', () => {
+    const long = 'Organize the chat navigation so branch and runtime names fit in the header'
+    assert.equal(truncateNavTitle(long, 36).length, 36)
+    assert.match(truncateNavTitle(long, 36), /…$/)
+  })
+})

--- a/src/lib/truncateLabel.ts
+++ b/src/lib/truncateLabel.ts
@@ -1,0 +1,41 @@
+/** Compact labels for the run header — full value lives in the tooltip. */
+
+const ELLIPSIS = '…'
+
+export function truncateMiddle(text: string, max: number): string {
+  const trimmed = text.trim()
+  if (max < 2 || trimmed.length <= max) return trimmed
+  if (max === 2) return ELLIPSIS
+  const keep = max - 1
+  const head = Math.ceil(keep / 2)
+  const tail = Math.floor(keep / 2)
+  return `${trimmed.slice(0, head)}${ELLIPSIS}${trimmed.slice(-tail)}`
+}
+
+export function truncateEnd(text: string, max: number): string {
+  const oneLine = text.replace(/\s+/g, ' ').trim()
+  if (oneLine.length <= max) return oneLine
+  if (max < 2) return ELLIPSIS
+  return `${oneLine.slice(0, max - 1).trimEnd()}${ELLIPSIS}`
+}
+
+/** Keeps the prefix before `/` and middle-truncates the branch slug. */
+export function truncateBranchLabel(branch: string, max = 26): string {
+  const trimmed = branch.trim()
+  if (trimmed.length <= max) return trimmed
+
+  const slash = trimmed.indexOf('/')
+  if (slash > 0 && slash < trimmed.length - 1) {
+    const prefix = trimmed.slice(0, slash + 1)
+    const rest = trimmed.slice(slash + 1)
+    const restBudget = max - prefix.length
+    if (restBudget >= 5) return prefix + truncateMiddle(rest, restBudget)
+  }
+
+  return truncateMiddle(trimmed, max)
+}
+
+/** Conversation titles beside the branch switcher. */
+export function truncateNavTitle(title: string, max = 36): string {
+  return truncateEnd(title, max)
+}

--- a/src/routes/runs.$runId.tsx
+++ b/src/routes/runs.$runId.tsx
@@ -12,6 +12,7 @@ import * as fns from '../fns'
 import { Chat } from '../components/Chat'
 import { ChatDebugMenuItem } from '../components/chat/ChatDebugToggle'
 import { ContextMeter } from '../components/chat/ContextMeter'
+import { ThreadStack } from '../components/chat/ThreadStack'
 import { TerminalPaletteMenuItems } from '../components/chat/TerminalPalettePicker'
 import { useChatTheme } from '../components/chat/ChatThemeProvider'
 import { DiffPanel } from '../components/DiffPanel'
@@ -43,6 +44,7 @@ import {
 import { defaultEffort, defaultModel, modelsForRuntime } from '../lib/models'
 import type { RuntimeMode } from '../lib/runtimeMode'
 import { isWorkspaceReady } from '../lib/workspaceReady'
+import { runListTitle } from '../lib/runPreview'
 import {
   NO_RUN_COMMITS,
   shortSha,
@@ -474,6 +476,7 @@ function RunDetail() {
               </Link>
 
               <WorkspaceBreadcrumb
+                projectId={project?.id}
                 projectName={project?.name}
                 branch={workspace?.branch}
                 isMainCheckout={workspace?.kind === 'main'}
@@ -481,6 +484,22 @@ function RunDetail() {
                 workspaces={workspaces}
                 branchDisabled={booting}
                 onRequestNewBranch={project ? () => setNewBranchOpen(true) : undefined}
+                trailing={
+                  run ? (
+                    <ThreadStack
+                      runId={run.id}
+                      title={runListTitle({
+                        trigger: run.trigger,
+                        taskName: run.taskName,
+                        prompt: firstPrompt,
+                      })}
+                      runtimeId={data?.runtime?.id ?? run.runtimeId}
+                      runtimeLabel={data?.runtime?.label ?? run.runtimeId}
+                      workspaceId={workspace?.id ?? run.workspaceId}
+                      projectId={project?.id ?? workspace?.projectId ?? ''}
+                    />
+                  ) : null
+                }
               />
 
               <div className="flex shrink-0 items-center gap-0.5">

--- a/src/server/conversationNavigation.ts
+++ b/src/server/conversationNavigation.ts
@@ -1,0 +1,83 @@
+import { runListTitle } from '../lib/runPreview'
+import { getDb } from './db'
+
+export type ConversationNavigationRun = {
+  id: string
+  chatTitle: string
+  runtimeId: string
+  runtimeLabel: string
+  startedAt: number
+  workspaceId: string
+  workspaceBranch: string
+  projectId: string
+  projectName: string
+  unread: boolean
+}
+
+export function listConversationNavigationRuns(): ConversationNavigationRun[] {
+  const db = getDb()
+  const labels = new Map(
+    (db.prepare('SELECT id, label FROM runtimes').all() as Array<{ id: string; label: string }>).map(
+      (row) => [row.id, row.label] as const,
+    ),
+  )
+  const rows = db
+    .prepare(
+      `SELECT r.id, r.runtimeId, r.trigger, r.taskName, r.startedAt, r.workspaceId,
+              r.lastReadAt, w.branch AS workspaceBranch, w.projectId,
+              p.name AS projectName,
+              (SELECT content FROM messages
+               WHERE runId = r.id AND role = 'user'
+               ORDER BY createdAt ASC LIMIT 1) AS firstPrompt,
+              (SELECT MAX(createdAt) FROM messages
+               WHERE runId = r.id AND role = 'assistant') AS lastAgentAt
+       FROM runs r
+       LEFT JOIN workspaces w ON w.id = r.workspaceId
+       LEFT JOIN projects p ON p.id = w.projectId
+       WHERE r.archivedAt IS NULL
+       ORDER BY r.startedAt DESC`,
+    )
+    .all() as Array<{
+    id: string
+    runtimeId: string
+    trigger: string
+    taskName: string | null
+    startedAt: number
+    workspaceId: string
+    lastReadAt: number
+    workspaceBranch: string | null
+    projectId: string | null
+    projectName: string | null
+    firstPrompt: string | null
+    lastAgentAt: number | null
+  }>
+
+  return rows.map((row) => ({
+    id: row.id,
+    chatTitle: runListTitle({
+      trigger: row.trigger,
+      taskName: row.taskName ?? '',
+      prompt: row.firstPrompt ?? '',
+    }),
+    runtimeId: row.runtimeId,
+    runtimeLabel: labels.get(row.runtimeId) ?? row.runtimeId,
+    startedAt: row.startedAt,
+    workspaceId: row.workspaceId,
+    workspaceBranch: row.workspaceBranch ?? '',
+    projectId: row.projectId ?? '',
+    projectName: row.projectName ?? '',
+    unread: (row.lastAgentAt ?? 0) > row.lastReadAt,
+  }))
+}
+
+export function getLatestRunForProject(projectId: string): { id: string } | null {
+  const row = getDb()
+    .prepare(
+      `SELECT r.id FROM runs r
+       JOIN workspaces w ON w.id = r.workspaceId
+       WHERE w.projectId = ? AND r.archivedAt IS NULL
+       ORDER BY r.startedAt DESC LIMIT 1`,
+    )
+    .get(projectId) as { id: string } | undefined
+  return row ?? null
+}

--- a/src/server/conversationNavigation.ts
+++ b/src/server/conversationNavigation.ts
@@ -17,9 +17,9 @@ export type ConversationNavigationRun = {
 export function listConversationNavigationRuns(): ConversationNavigationRun[] {
   const db = getDb()
   const labels = new Map(
-    (db.prepare('SELECT id, label FROM runtimes').all() as Array<{ id: string; label: string }>).map(
-      (row) => [row.id, row.label] as const,
-    ),
+    (
+      db.prepare('SELECT id, label FROM runtimes').all() as Array<{ id: string; label: string }>
+    ).map((row) => [row.id, row.label] as const),
   )
   const rows = db
     .prepare(


### PR DESCRIPTION
## Summary
- Finalize the corrected conversation-navigation work from #57/#80 on current `main`.
- Keep database relocation separate; that change is already on `main`.
- Includes the formatting corrections required by CI.

## Test plan
- [ ] Switch between conversations in the current worktree.
- [ ] Search sibling worktrees and projects.
- [ ] Switch project/workspace from the breadcrumb and open the latest run.