### PR TITLE
fix: keep pre-push lint checks read-only

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -15,14 +15,9 @@ run_pnpm() {
   fi
 }
 
-status_before="$(git status --porcelain)"
-run_pnpm lint:fix
-status_after="$(git status --porcelain)"
-
-if [ "$status_before" != "$status_after" ]; then
-  echo "pre-push: pnpm lint:fix rewrote files. Commit them and push again." >&2
-  git status --short >&2
+if ! run_pnpm lint; then
+  echo >&2
+  echo "pre-push: lint failed without changing your files." >&2
+  echo "Run 'pnpm lint:fix', review the fixes, then commit them before pushing." >&2
   exit 1
 fi
-
-run_pnpm lint

--- a/changelog.d/pre-push-lint.md
+++ b/changelog.d/pre-push-lint.md
@@ -1,0 +1,1 @@
+Your pre-push hook no longer rewrites files while a push is in progress. It now checks lint only and tells you to run `pnpm lint:fix` yourself when fixes are needed.


### PR DESCRIPTION
## Summary
- Isolate the remaining pre-push change from #56 on current `main`.
- Make the pre-push hook run `pnpm lint` only instead of rewriting files with `pnpm lint:fix` during a push.
- Add a focused changelog entry for the behavior change.

## Test plan
- [ ] Push with clean lint and confirm the hook passes without modifying files.
- [ ] Introduce a lint failure and confirm the hook fails with guidance to run `pnpm lint:fix`.
- [ ] Confirm the PR contains only the isolated pre-push behavior and changelog.