### PR TITLE
fix(security): harden git argument handling

### DIFF
--- a/changelog.d/git-leading-dash-args.md
+++ b/changelog.d/git-leading-dash-args.md
@@ -1,0 +1,2 @@
+- Clone URLs, branch names, and worktree refs that start with `-` are refused
+  instead of being passed to git as options.

--- a/changelog.d/git-leading-dash-args.md
+++ b/changelog.d/git-leading-dash-args.md
@@ -1,2 +1,1 @@
-- Clone URLs, branch names, and worktree refs that start with `-` are refused
-  instead of being passed to git as options.
+You no longer risk Git interpreting clone URLs, branch names, worktree refs, or filesystem paths as command options when Open Run passes them to Git.

--- a/changelog.d/git-leading-dash-args.md
+++ b/changelog.d/git-leading-dash-args.md
@@ -1,1 +1,1 @@
-You no longer risk Git interpreting clone URLs, branch names, worktree refs, or filesystem paths as command options when Open Run passes them to Git.
+You no longer risk Git treating clone URLs, branch names, worktree refs, or filesystem paths as command options when Open Run passes them to Git.

--- a/src/server/git.test.ts
+++ b/src/server/git.test.ts
@@ -8,7 +8,9 @@ import {
   captureBaseSnapshot,
   changedFiles,
   changedFilesAsync,
+  cloneRepo,
   commit,
+  createBranch,
   createPullRequest,
   discard,
   discardHunk,
@@ -247,6 +249,18 @@ describe('discardHunk', () => {
 function parseHunkCount(diff: string): number {
   return diff.split('\n').filter((line) => line.startsWith('@@ ')).length
 }
+
+describe('git argv leading-dash refusal', () => {
+  it('createBranch refuses a name that starts with -', () => {
+    const cwd = makeRepo()
+    assert.throws(() => createBranch(cwd, '--help'), /Invalid branch name/)
+  })
+
+  it('cloneRepo refuses a URL that starts with -', () => {
+    const dest = join(makeRepo(), 'clone-dest')
+    assert.throws(() => cloneRepo({ url: '--upload-pack=true', dest }), /Invalid clone URL/)
+  })
+})
 
 describe('push / createPullRequest origin gate', () => {
   it('push refuses a repo with no origin remote', () => {

--- a/src/server/git.ts
+++ b/src/server/git.ts
@@ -68,6 +68,15 @@ function refuseLeadingDash(value: string, label: string): string {
   return trimmed
 }
 
+/** Validate filesystem paths without changing the exact path the caller supplied. */
+function refuseUnsafePath(value: string, label: string): string {
+  if (!value.trim()) throw new Error(`${label} is required`)
+  if (value.startsWith('-') || value.includes('\0')) {
+    throw new Error(`Invalid ${label}`)
+  }
+  return value
+}
+
 function gitEnv(extra?: Record<string, string>): NodeJS.ProcessEnv {
   return { ...process.env, GIT_OPTIONAL_LOCKS: '0', ...extra }
 }
@@ -777,7 +786,7 @@ export function commit(cwd: string, message: string, paths?: string[]): { sha: s
 /** Put a registered worktree on its configured branch at its immutable base. */
 export function resetWorktree(cwd: string, branch: string, baseCommit: string): void {
   if (!isRepo(cwd)) throw new Error('Not a git repository')
-  if (!branch.trim()) throw new Error('A branch is required to restore a worktree')
+  const safeBranch = refuseLeadingDash(branch, 'branch name')
   if (!resolveCommit(cwd, baseCommit)) {
     throw new Error('The workspace restore base commit is unavailable')
   }
@@ -789,8 +798,8 @@ export function resetWorktree(cwd: string, branch: string, baseCommit: string): 
   // build caches. Removing those turns a restore into a re-setup.
   gitOrThrow(cwd, ['clean', '-fd'])
 
-  if (currentBranch(cwd) !== branch) {
-    gitOrThrow(cwd, ['checkout', branch])
+  if (currentBranch(cwd) !== safeBranch) {
+    gitOrThrow(cwd, ['checkout', safeBranch])
   }
 
   gitOrThrow(cwd, ['reset', '--hard', baseCommit])
@@ -1207,7 +1216,7 @@ export function addWorktree(input: {
   const { repoPath, newBranch } = input
   const branch = refuseLeadingDash(input.branch, 'branch name')
   const baseRef = refuseLeadingDash(input.baseRef, 'base ref')
-  const path = refuseLeadingDash(input.path, 'worktree path')
+  const path = refuseUnsafePath(input.path, 'worktree path')
   if (newBranch) {
     gitOrThrow(repoPath, ['worktree', 'add', '-b', branch, '--', path, baseRef])
   } else {
@@ -1217,7 +1226,8 @@ export function addWorktree(input: {
 
 /** Remove a worktree, then prune stale metadata. Prune failure is not fatal. */
 export function removeWorktree(repoPath: string, path: string, force: boolean): void {
-  const args = ['worktree', 'remove', ...(force ? ['--force'] : []), path]
+  const safePath = refuseUnsafePath(path, 'worktree path')
+  const args = ['worktree', 'remove', ...(force ? ['--force'] : []), '--', safePath]
   gitOrThrow(repoPath, args)
   git(repoPath, ['worktree', 'prune'])
 }
@@ -1230,7 +1240,7 @@ export function removeWorktree(repoPath: string, path: string, force: boolean): 
  */
 export function cloneRepo(input: { url: string; dest: string }): void {
   const url = refuseLeadingDash(input.url, 'clone URL')
-  const dest = refuseLeadingDash(input.dest, 'clone destination')
+  const dest = refuseUnsafePath(input.dest, 'clone destination')
   const res = spawnSync('git', ['clone', '--', url, dest], {
     encoding: 'utf8',
     maxBuffer: MAX_BUFFER,

--- a/src/server/git.ts
+++ b/src/server/git.ts
@@ -57,6 +57,16 @@ export type RepoInfo = {
 
 const MAX_BUFFER = 32 * 1024 * 1024
 
+/** Reject strings that git would treat as options rather than values. */
+function refuseLeadingDash(value: string, label: string): string {
+  const trimmed = value.trim()
+  if (!trimmed) throw new Error(`${label} is required`)
+  if (trimmed.startsWith('-') || trimmed.includes('\0')) {
+    throw new Error(`Invalid ${label}`)
+  }
+  return trimmed
+}
+
 function gitEnv(extra?: Record<string, string>): NodeJS.ProcessEnv {
   return { ...process.env, GIT_OPTIONAL_LOCKS: '0', ...extra }
 }
@@ -267,7 +277,7 @@ function untrackedLineStats(
   cwd: string,
   path: string,
 ): { additions: number; deletions: number; binary: boolean } {
-  const stat = git(cwd, ['diff', '--no-index', '--numstat', '/dev/null', path]).stdout
+  const stat = git(cwd, ['diff', '--no-index', '--numstat', '--', '/dev/null', path]).stdout
   const m = stat.match(/^(\d+|-)\t(\d+|-)\t/)
   const binary = m ? m[1] === '-' : false
   return {
@@ -657,7 +667,14 @@ export async function changedFilesAsync(cwd: string, since?: string): Promise<Di
   const untrackedPaths = untrackedRes.stdout.split('\0').filter((p) => p.length > 0)
   await Promise.all(
     untrackedPaths.map(async (path) => {
-      const statsRes = await gitAsync(cwd, ['diff', '--no-index', '--numstat', '/dev/null', path])
+      const statsRes = await gitAsync(cwd, [
+        'diff',
+        '--no-index',
+        '--numstat',
+        '--',
+        '/dev/null',
+        path,
+      ])
       const statMatch = statsRes.stdout.match(/^(\d+|-)\t(\d+|-)\t/)
       const binary = statMatch ? statMatch[1] === '-' : false
       const additions = binary || !statMatch ? 0 : Number(statMatch[1])
@@ -778,8 +795,10 @@ export function resetWorktree(cwd: string, branch: string, baseCommit: string): 
 
 /** Create and switch to a new branch. */
 export function createBranch(cwd: string, name: string) {
-  gitOrThrow(cwd, ['checkout', '-b', name])
-  return { branch: name }
+  const branch = refuseLeadingDash(name, 'branch name')
+  // `-b` consumes the next argv as the name, so `--` cannot sit between them.
+  gitOrThrow(cwd, ['checkout', '-b', branch])
+  return { branch }
 }
 
 /** Push the current branch, setting upstream when it has none. */
@@ -1182,11 +1201,14 @@ export function addWorktree(input: {
   baseRef: string
   newBranch: boolean
 }): void {
-  const { repoPath, branch, path, baseRef, newBranch } = input
+  const { repoPath, newBranch } = input
+  const branch = refuseLeadingDash(input.branch, 'branch name')
+  const baseRef = refuseLeadingDash(input.baseRef, 'base ref')
+  const path = refuseLeadingDash(input.path, 'worktree path')
   if (newBranch) {
-    gitOrThrow(repoPath, ['worktree', 'add', '-b', branch, path, baseRef])
+    gitOrThrow(repoPath, ['worktree', 'add', '-b', branch, '--', path, baseRef])
   } else {
-    gitOrThrow(repoPath, ['worktree', 'add', path, branch])
+    gitOrThrow(repoPath, ['worktree', 'add', '--', path, branch])
   }
 }
 
@@ -1204,7 +1226,9 @@ export function removeWorktree(repoPath: string, path: string, force: boolean): 
  * prompt from a headless server process.
  */
 export function cloneRepo(input: { url: string; dest: string }): void {
-  const res = spawnSync('git', ['clone', input.url, input.dest], {
+  const url = refuseLeadingDash(input.url, 'clone URL')
+  const dest = refuseLeadingDash(input.dest, 'clone destination')
+  const res = spawnSync('git', ['clone', '--', url, dest], {
     encoding: 'utf8',
     maxBuffer: MAX_BUFFER,
     env: { ...process.env, GIT_TERMINAL_PROMPT: '0', GIT_ASKPASS: '' },


### PR DESCRIPTION
## Summary
- Rebase the original #50 security hardening onto the finalized repository state.
- Refuse option-like Git refs and persisted branch names before invoking Git.
- Keep filesystem paths byte-for-byte intact while validating them, and use explicit `--` separators for worktree removal and clone/worktree paths.
- Address all review findings from #50 and align the changelog entry with the repository style.

Supersedes #50 and temporary staging #89.

## Test plan
- [ ] Confirm clone URLs and branch/base refs beginning with `-` are refused.
- [ ] Confirm `resetWorktree` refuses an unsafe persisted branch.
- [ ] Confirm worktree/clone filesystem paths are not trimmed.
- [ ] Confirm `removeWorktree` and path-taking Git commands use `--` separators.
- [ ] Run CI, tests, typecheck, build, and audit.