### PR TITLE
fix(chat): hide transcript behind composer

### DIFF
--- a/changelog.d/composer-backdrop.md
+++ b/changelog.d/composer-backdrop.md
@@ -1,0 +1,1 @@
+You no longer see distracting conversation content through the composer area while writing a follow-up.

--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -1255,7 +1255,7 @@ export function Chat({
           ref={composerOverlayRef}
           className="chat-composer-dock pointer-events-none absolute inset-x-0 bottom-0 z-20"
         >
-          <div className="chat-composer-horizontal-inset pointer-events-auto relative">
+          <div className="chat-composer-horizontal-inset pointer-events-auto relative pb-[calc(env(safe-area-inset-bottom)+0.75rem)] sm:pb-[calc(env(safe-area-inset-bottom)+1rem)]">
             <div className="mx-auto flex w-full min-w-0 max-w-[51rem] flex-col items-stretch">
               {pullRequest ? (
                 <div className="relative z-[6] mx-auto -mb-[2px] w-[92%]">

--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -1253,7 +1253,7 @@ export function Chat({
 
         <div
           ref={composerOverlayRef}
-          className="pointer-events-none absolute inset-x-0 bottom-0 z-20 pt-1.5 sm:pt-2"
+          className="chat-composer-dock pointer-events-none absolute inset-x-0 bottom-0 z-20 pt-1.5 sm:pt-2"
         >
           <div className="chat-composer-horizontal-inset pointer-events-auto relative">
             <div className="mx-auto flex w-full min-w-0 max-w-3xl flex-col items-stretch pl-2">

--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -1253,7 +1253,7 @@ export function Chat({
 
         <div
           ref={composerOverlayRef}
-          className="chat-composer-dock pointer-events-none absolute inset-x-0 bottom-0 z-20 pt-1.5 sm:pt-2"
+          className="chat-composer-dock pointer-events-none absolute inset-x-0 bottom-0 z-20"
         >
           <div className="chat-composer-horizontal-inset pointer-events-auto relative">
             <div className="mx-auto flex w-full min-w-0 max-w-3xl flex-col items-stretch pl-2">
@@ -1306,7 +1306,7 @@ export function Chat({
                   pullRequest ||
                   pullRequestError
                     ? 'relative z-10 w-full'
-                    : 'w-full pt-2'
+                    : 'w-full'
                 }
                 disabled={
                   !running && ((!canFollowUp && !switching) || switchBlockedReason !== null)

--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -1256,7 +1256,7 @@ export function Chat({
           className="chat-composer-dock pointer-events-none absolute inset-x-0 bottom-0 z-20"
         >
           <div className="chat-composer-horizontal-inset pointer-events-auto relative">
-            <div className="mx-auto flex w-full min-w-0 max-w-3xl flex-col items-stretch pl-2">
+            <div className="mx-auto flex w-full min-w-0 max-w-[51rem] flex-col items-stretch">
               {pullRequest ? (
                 <div className="relative z-[6] mx-auto -mb-[2px] w-[92%]">
                   <PullRequestChip pr={pullRequest} />

--- a/src/routes/runs.$runId.tsx
+++ b/src/routes/runs.$runId.tsx
@@ -850,7 +850,7 @@ function RunDetail() {
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4">
           <div className="w-full max-w-md rounded-2xl border border-border bg-elevated p-5 shadow-2xl">
             <div className="mb-1 flex items-center gap-2 text-sm font-medium text-foreground">
-              <ChevronRight className="size-4 opacity-0" />
+              <ChevronRight className="size-4" />
               New branch workspace
             </div>
             <p className="mb-4 text-xs text-muted-foreground">

--- a/src/routes/runs.new.tsx
+++ b/src/routes/runs.new.tsx
@@ -353,7 +353,7 @@ function NewRun() {
           </div>
         )}
 
-        <div className="chat-composer-dock pointer-events-none absolute inset-x-0 bottom-0 z-20 pt-1.5 sm:pt-2">
+        <div className="chat-composer-dock pointer-events-none absolute inset-x-0 bottom-0 z-20">
           <div className="chat-composer-horizontal-inset pointer-events-auto relative z-10">
             <Composer
               disabled={blockedReason !== null}

--- a/src/routes/runs.new.tsx
+++ b/src/routes/runs.new.tsx
@@ -353,7 +353,7 @@ function NewRun() {
           </div>
         )}
 
-        <div className="pointer-events-none absolute inset-x-0 bottom-0 z-20 pt-1.5 sm:pt-2">
+        <div className="chat-composer-dock pointer-events-none absolute inset-x-0 bottom-0 z-20 pt-1.5 sm:pt-2">
           <div className="chat-composer-horizontal-inset pointer-events-auto relative z-10">
             <Composer
               disabled={blockedReason !== null}

--- a/src/styles.css
+++ b/src/styles.css
@@ -313,7 +313,7 @@ body {
   position: absolute;
   inset-inline: 0;
   bottom: 100%;
-  height: 3rem;
+  height: 6rem;
   pointer-events: none;
   content: '';
   background: linear-gradient(

--- a/src/styles.css
+++ b/src/styles.css
@@ -313,7 +313,7 @@ body {
   position: absolute;
   inset-inline: 0;
   bottom: 100%;
-  height: 6rem;
+  height: 2rem;
   pointer-events: none;
   content: '';
   background: linear-gradient(

--- a/src/styles.css
+++ b/src/styles.css
@@ -305,6 +305,20 @@ body {
   padding-inline-end: calc(env(safe-area-inset-right) + 0.75rem);
 }
 
+.chat-composer-dock {
+  background: var(--bg-chrome);
+}
+
+.chat-composer-dock::before {
+  position: absolute;
+  inset-inline: 0;
+  bottom: 100%;
+  height: 2rem;
+  pointer-events: none;
+  content: '';
+  background: linear-gradient(to bottom, transparent, var(--bg-chrome));
+}
+
 @media (min-width: 40rem) {
   .chat-composer-horizontal-inset {
     padding-inline-start: calc(env(safe-area-inset-left) + 1.25rem);

--- a/src/styles.css
+++ b/src/styles.css
@@ -313,10 +313,18 @@ body {
   position: absolute;
   inset-inline: 0;
   bottom: 100%;
-  height: 2rem;
+  height: 3rem;
   pointer-events: none;
   content: '';
-  background: linear-gradient(to bottom, transparent, var(--bg-chrome));
+  background: linear-gradient(
+    to bottom,
+    transparent 0%,
+    color-mix(in srgb, var(--bg-chrome) 8%, transparent) 24%,
+    color-mix(in srgb, var(--bg-chrome) 24%, transparent) 45%,
+    color-mix(in srgb, var(--bg-chrome) 48%, transparent) 64%,
+    color-mix(in srgb, var(--bg-chrome) 74%, transparent) 82%,
+    var(--bg-chrome) 100%
+  );
 }
 
 @media (min-width: 40rem) {


### PR DESCRIPTION
## Summary
- Hide distracting transcript content beneath the follow-up composer with an opaque dock and subtle fade.
- Apply the same composer treatment when starting a new run.

## Test plan
- [x] Open an existing run with a long transcript and confirm content fades out before reaching the composer.
- [x] Scroll to the end of an existing run and confirm the final content remains fully visible above the composer.
- [x] Open `/runs/new` and confirm the composer dock cleanly separates the form from the input.