### PR TITLE
feat(tasks): make the demo automation detail interactive

### DIFF
--- a/changelog.d/automation-detail-demo.md
+++ b/changelog.d/automation-detail-demo.md
@@ -1,0 +1,1 @@
+You can now open the featured automation in demo mode, change its configuration interactively, and apply those changes to the page-local preview without saving or running anything.

--- a/src/components/ComposerControls.tsx
+++ b/src/components/ComposerControls.tsx
@@ -3,7 +3,7 @@
  *
  * Layout adapted from the t3code chat composer footer (MIT, T3 Tools Inc.).
  */
-import { useLayoutEffect, useRef, useState, type ReactNode } from 'react'
+import { useEffect, useLayoutEffect, useRef, useState, type ReactNode } from 'react'
 import { useClickOutside } from '../hooks/useClickOutside'
 import { createPortal } from 'react-dom'
 import {
@@ -71,6 +71,8 @@ export function FooterMenu({
   invalid,
   'aria-describedby': ariaDescribedBy,
   onOpen,
+  initiallyOpen = false,
+  keepOpen = false,
   children,
 }: {
   label: string
@@ -85,6 +87,10 @@ export function FooterMenu({
   invalid?: boolean
   'aria-describedby'?: string
   onOpen?: () => void
+  /** Open after hydration, used by static previews that showcase a picker. */
+  initiallyOpen?: boolean
+  /** Keep a preview menu visible while interacting with the rest of the page. */
+  keepOpen?: boolean
   children: (close: () => void) => ReactNode
 }) {
   const [open, setOpen] = useState(false)
@@ -98,7 +104,15 @@ export function FooterMenu({
     maxHeight: number
   } | null>(null)
 
-  useClickOutside(open, () => setOpen(false), [triggerRef, menuRef])
+  useEffect(() => {
+    if (initiallyOpen) setOpen(true)
+  }, [initiallyOpen])
+
+  const close = () => {
+    if (!keepOpen) setOpen(false)
+  }
+
+  useClickOutside(open, close, [triggerRef, menuRef])
 
   useLayoutEffect(() => {
     if (!open || !buttonRef.current) {
@@ -149,7 +163,7 @@ export function FooterMenu({
       aria-describedby={ariaDescribedBy}
       onClick={() => {
         if (!open) onOpen?.()
-        setOpen((v) => !v)
+        if (!keepOpen) setOpen((v) => !v)
       }}
       className={
         compact
@@ -207,7 +221,7 @@ export function FooterMenu({
               }}
               className="min-w-52 overflow-x-hidden overflow-y-auto overscroll-contain rounded-xl border border-border bg-elevated p-1 shadow-xl shadow-black/40"
             >
-              {children(() => setOpen(false))}
+              {children(close)}
             </div>,
             document.body,
           )
@@ -844,12 +858,16 @@ export function RuntimePicker({
   runtimeId,
   disabled,
   align = 'end',
+  initiallyOpen,
+  keepOpen,
   onChange,
 }: {
   runtimes: RuntimeOption[]
   runtimeId: string
   disabled?: boolean
   align?: 'start' | 'end'
+  initiallyOpen?: boolean
+  keepOpen?: boolean
   onChange: (id: string) => void
 }) {
   const { prefs, remember } = usePickerPrefs()
@@ -869,6 +887,8 @@ export function RuntimePicker({
       title={selected.description || selected.label}
       disabled={disabled}
       align={align}
+      initiallyOpen={initiallyOpen}
+      keepOpen={keepOpen}
       leading={
         <ProviderIcon kind={modelKindForBin(selected.bin)} className="h-3.5 w-3.5 shrink-0" />
       }

--- a/src/components/TaskForm.tsx
+++ b/src/components/TaskForm.tsx
@@ -905,12 +905,15 @@ export function TaskForm({
   onCancel,
   readiness,
   workspaceChangeBlockedReason,
+  demoPreview = false,
 }: {
   initial?: Partial<TaskFormValues>
   onSaved: (id: string) => void
   onCancel: () => void
   readiness?: ReactNode
   workspaceChangeBlockedReason?: string | null
+  /** Interactive, page-local preview that never persists an automation. */
+  demoPreview?: boolean
 }) {
   const { data: runtimes } = useRuntimes()
   const { data: projects } = useProjects()
@@ -1229,6 +1232,9 @@ export function TaskForm({
   // Validate + save. Returns the saved task, or null when validation blocked
   // the write (errors are surfaced inline). Shared by Create/Save and "Run once".
   const persist = async (): Promise<{ id: string; name: string } | null> => {
+    if (demoPreview) {
+      return { id: v.id ?? 'demo-task-preview', name: v.name.trim() || 'Untitled' }
+    }
     const cron = v.cron.trim()
     if (!isValidCron(cron)) {
       setTriggerError(invalidCronMessage(cron))
@@ -1319,13 +1325,17 @@ export function TaskForm({
   const pristine = Boolean(v.id) && !dirty
   const saveBlockReason = save.isPending
     ? 'Saving…'
-    : workspaceBlockReason
-      ? workspaceBlockReason
-      : !promptUsable
-        ? emptyTaskPromptMessage()
-        : pristine
-          ? 'No changes to save'
-          : undefined
+    : demoPreview
+      ? pristine
+        ? 'No preview changes to apply'
+        : undefined
+      : workspaceBlockReason
+        ? workspaceBlockReason
+        : !promptUsable
+          ? emptyTaskPromptMessage()
+          : pristine
+            ? 'No changes to save'
+            : undefined
 
   const submit = async (e: React.FormEvent) => {
     e.preventDefault()
@@ -1334,7 +1344,7 @@ export function TaskForm({
     setDirty(false)
     toast.add({
       type: 'success',
-      title: v.id ? 'Changes saved' : 'Automation created',
+      title: demoPreview ? 'Preview updated' : v.id ? 'Changes saved' : 'Automation created',
     })
     onSaved(saved.id)
   }
@@ -1358,9 +1368,19 @@ export function TaskForm({
               <Button
                 type="submit"
                 variant="primary"
-                disabled={save.isPending || !workspaceUsable || !promptUsable || pristine}
+                disabled={
+                  save.isPending ||
+                  (!demoPreview && (!workspaceUsable || !promptUsable)) ||
+                  pristine
+                }
               >
-                {save.isPending ? 'Saving…' : v.id ? 'Save changes' : 'Create'}
+                {save.isPending
+                  ? 'Saving…'
+                  : demoPreview
+                    ? 'Apply preview'
+                    : v.id
+                      ? 'Save changes'
+                      : 'Create'}
               </Button>
             </span>
           </div>
@@ -1603,6 +1623,8 @@ export function TaskForm({
                   runtimes={runtimes}
                   runtimeId={v.runtimeId}
                   align="start"
+                  initiallyOpen={demoPreview}
+                  keepOpen={demoPreview}
                   onChange={changeRuntimeId}
                 />
               ) : null}
@@ -1612,6 +1634,8 @@ export function TaskForm({
                     runtimes={runtimes}
                     runtimeId={v.runtimeId}
                     align="end"
+                    initiallyOpen={demoPreview}
+                    keepOpen={demoPreview}
                     onChange={changeRuntimeId}
                   />
                 </div>

--- a/src/lib/demoData.test.ts
+++ b/src/lib/demoData.test.ts
@@ -1,6 +1,12 @@
 import assert from 'node:assert/strict'
 import { after, describe, it } from 'node:test'
-import { DEMO_RUNNING_TASK_ID, demoRuns, demoTasks, isDemoMode } from './demoData.ts'
+import {
+  DEMO_RUNNING_TASK_ID,
+  demoRuns,
+  demoTaskDetail,
+  demoTasks,
+  isDemoMode,
+} from './demoData.ts'
 
 describe('isDemoMode', () => {
   const prevOpenrun = process.env.OPENRUN_DEMO
@@ -44,5 +50,18 @@ describe('demo lists', () => {
     assert.ok(rows.some((t) => t.webhookIntegrationId && !t.cron))
     assert.ok(rows.some((t) => t.enabled === 0))
     assert.ok(rows.some((t) => t.queuedCount > 1))
+  })
+})
+
+describe('demo automation detail', () => {
+  it('provides a ready, isolated preview for the featured automation', () => {
+    const task = demoTaskDetail(DEMO_RUNNING_TASK_ID, 1_700_000_000_000)
+    assert.equal(task?.name, 'Nightly dependency bump')
+    assert.equal(task?.workspaceHealth?.code, 'ok')
+    assert.equal(task?.readinessBlockers.length, 0)
+  })
+
+  it('does not fabricate details for the other demo rows', () => {
+    assert.equal(demoTaskDetail('demo-task-2'), null)
   })
 })

--- a/src/lib/demoData.ts
+++ b/src/lib/demoData.ts
@@ -2,6 +2,7 @@
  * Sample Runs + Automations for screenshots. `pnpm dev -- --demo` sets
  * OPENRUN_DEMO=1; lists overlay this on top of the real DB (nothing is written).
  */
+import type { TaskWithMeta } from '../fns'
 
 export function isDemoMode(): boolean {
   const raw = (process.env.OPENRUN_DEMO ?? process.env.AGENTOPS_DEMO ?? '').trim().toLowerCase()
@@ -21,10 +22,85 @@ export type DemoRun = {
 }
 
 export const DEMO_RUNNING_TASK_ID = 'demo-task-1'
+export const DEMO_DETAIL_TASK_ID = DEMO_RUNNING_TASK_ID
 export const DEMO_DETAIL_RUN_ID = 'demo-run-5'
+
+export function isDemoDetailTask(taskId: string): boolean {
+  return taskId === DEMO_DETAIL_TASK_ID
+}
 
 export function isDemoDetailRun(runId: string): boolean {
   return runId === DEMO_DETAIL_RUN_ID
+}
+
+export function demoTaskDetail(taskId: string, now: number = Date.now()): TaskWithMeta | null {
+  if (!isDemoDetailTask(taskId)) return null
+
+  const cwd = '/Users/demo/Developer/open-run-nightly-deps'
+  return {
+    id: taskId,
+    name: 'Nightly dependency bump',
+    description: 'Keep dependencies current and leave a reviewed pull request ready each morning.',
+    runtimeId: 'grok',
+    prompt: `Review the workspace for outdated dependencies.
+
+Apply safe patch and minor updates, update the lockfile, and run the existing checks. Summarize anything that needs a manual major-version migration.`,
+    cwd,
+    workspaceId: 'demo-workspace-nightly-deps',
+    cron: '0 18 * * *',
+    enabled: 1,
+    model: '',
+    effort: 'high',
+    webhookIntegrationId: '',
+    webhookEvents: '[]',
+    webhookFilters: '{}',
+    verifyEnabled: 1,
+    maxRepairAttempts: 1,
+    timeoutMs: 30 * 60_000,
+    resumeSessionId: '',
+    resumeSessionLabel: '',
+    fireOnce: 0,
+    scheduledAt: 0,
+    requireIsolation: 1,
+    requireGhAuth: 1,
+    createdAt: now - 30 * 86400_000,
+    updatedAt: now - 2 * 86400_000,
+    lastRunAt: now - 2 * 60_000,
+    runtimeLabel: 'Grok CLI',
+    nextRunAt: now + 20 * 60_000,
+    cronValid: true,
+    workspaceValid: true,
+    workspaceReady: true,
+    workspaceStatus: 'ready',
+    runtimeInstalled: true,
+    runtimeValid: true,
+    runtimeBin: 'grok',
+    promptValid: true,
+    resumeSessionValid: true,
+    checkCount: 3,
+    queuedCount: 0,
+    effectiveTimeoutMs: 30 * 60_000,
+    lastScheduleFire: null,
+    workspaceKind: 'worktree',
+    workspaceHealth: {
+      code: 'ok',
+      path: cwd,
+      configuredBranch: 'chore/nightly-dependencies',
+      actualBranch: 'chore/nightly-dependencies',
+      dirty: false,
+      detail: '',
+    },
+    requiresGh: true,
+    ghInstalled: true,
+    ghAuthenticated: true,
+    unattendedBlockedReason: null,
+    activeRunId: null,
+    promptDeliveryValid: true,
+    promptDeliveryReason: null,
+    triggerReady: true,
+    triggerBlockReason: null,
+    readinessBlockers: [],
+  }
 }
 
 export type DemoTask = {

--- a/src/lib/queries.ts
+++ b/src/lib/queries.ts
@@ -9,7 +9,7 @@ import {
 } from './applyRunLiveEvent'
 import { useActivityStreamHealthy } from './useActivityLive'
 import { demoConversation, demoFileDiff, demoRunWorkspace } from './demoConversation.ts'
-import { isDemoDetailRun, isDemoMode } from './demoData.ts'
+import { demoTaskDetail, isDemoDetailRun, isDemoDetailTask, isDemoMode } from './demoData.ts'
 import { fileToBase64 } from './attachments.ts'
 import { newMessageId } from './messageId.ts'
 import type { PlanProposal } from './planProposals.ts'
@@ -222,10 +222,11 @@ export function useTasks() {
 
 export function useTask(id: string) {
   const streamHealthy = useActivityStreamHealthy()
+  const demo = isDemoMode() && isDemoDetailTask(id)
   return useQuery({
     queryKey: ['task', id],
-    queryFn: () => fns.getTask({ data: { id } }),
-    refetchInterval: streamHealthy ? 15_000 : 5000,
+    queryFn: () => (demo ? demoTaskDetail(id) : fns.getTask({ data: { id } })),
+    refetchInterval: demo ? false : streamHealthy ? 15_000 : 5000,
   })
 }
 
@@ -318,13 +319,17 @@ export function useRuns(
   opts?: { limit?: number; offset?: number },
 ) {
   const streamHealthy = useActivityStreamHealthy()
+  const demoTask = isDemoMode() && Boolean(taskId && isDemoDetailTask(taskId))
   const limit = opts?.limit ?? 100
   const offset = opts?.offset ?? 0
   return useQuery({
     queryKey: ['runs', taskId ?? 'all', includeArchived ? 'archived' : 'active', limit, offset],
-    queryFn: () => fns.listRuns({ data: { taskId, limit, offset, includeArchived } }),
+    queryFn: () =>
+      demoTask
+        ? Promise.resolve([])
+        : fns.listRuns({ data: { taskId, limit, offset, includeArchived } }),
     // Activity SSE invalidates on run_changed; poll only when the stream is down.
-    refetchInterval: streamHealthy ? false : 3000,
+    refetchInterval: demoTask || streamHealthy ? false : 3000,
   })
 }
 

--- a/src/routes/tasks.$taskId.tsx
+++ b/src/routes/tasks.$taskId.tsx
@@ -6,6 +6,7 @@ import { WorkspaceReadiness } from '../components/WorkspaceReadiness'
 import { useTopBarActions } from '../components/AppChrome'
 import { Button, Card, EmptyState, StatusBadge, VerdictBadge } from '../components/ui'
 import { duration, relativeTime } from '../lib/format'
+import { isDemoDetailTask, isDemoMode } from '../lib/demoData.ts'
 import { useDeleteTask, useRunNow, useRuns, useTask } from '../lib/queries'
 import { runNowBlockedReason } from '../lib/runNowGate'
 import { taskFormInitial } from '../lib/taskFormInitial'
@@ -17,6 +18,7 @@ export const Route = createFileRoute('/tasks/$taskId')({
 
 function TaskDetail() {
   const { taskId } = Route.useParams()
+  const demo = isDemoMode() && isDemoDetailTask(taskId)
   const { data: task, isLoading } = useTask(taskId)
   const { data: runs } = useRuns(taskId)
   const navigate = useNavigate()
@@ -27,7 +29,7 @@ function TaskDetail() {
   const runBlocked = task ? runNowBlockedReason(task) : null
 
   useTopBarActions(
-    task ? (
+    task && !demo ? (
       <>
         <Button
           variant="primary"
@@ -94,10 +96,12 @@ function TaskDetail() {
       <TaskForm
         key={task.id}
         initial={taskFormInitial(task)}
-        readiness={<WorkspaceReadiness task={task} />}
+        readiness={demo ? undefined : <WorkspaceReadiness task={task} />}
         workspaceChangeBlockedReason={taskWorkspaceChangeBlockedReason(task)}
+        demoPreview={demo}
         onCancel={() => navigate({ to: '/tasks' })}
         onSaved={() => {
+          if (demo) return
           qc.invalidateQueries({ queryKey: ['task', taskId] })
           qc.invalidateQueries({ queryKey: ['tasks'] })
         }}


### PR DESCRIPTION
## Summary

- The featured demo automation now opens a full detail page in `--demo` mode, served from page-local sample data instead of the database, so a screenshot run never depends on a real automation existing.
- You can change that preview's configuration — runtime, schedule, prompt — and apply it to the page without saving anything or offering Run now / Delete.
- The runtime picker can be asked to start open and stay open, so a preview can showcase it while the rest of the page is still usable.

## Test plan

- [ ] `pnpm dev -- --demo`, open Automations, click "Nightly dependency bump" — the detail page renders with a ready worktree and no readiness blockers.
- [ ] On that page the top bar shows no Run now / Delete, the runtime picker is already open and stays open when clicking elsewhere.
- [ ] Change the runtime or the prompt, press "Apply preview" — a "Preview updated" toast appears, nothing is written to `~/.openrun/openrun.db`, and the button re-disables with "No preview changes to apply".
- [ ] Open a different demo automation row — it still resolves against the real DB and behaves as before.
- [ ] Without `--demo`, open any real automation — Run now, Delete, readiness and saving all work unchanged.
