### PR TITLE
feat(mobile): start a run from a paired phone

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -212,6 +212,8 @@ Neither hook may open an `EventSource` of its own.
 | Supervised allow/deny | `components/Chat.tsx`; `fns.answerApproval`; `useAnswerApproval` in `lib/queries.ts` |
 | Command preview (Runtimes only) | `components/CommandPreview.tsx`; `server/commandPreview.ts`; `useCommandPreview` in `lib/queries.ts` |
 | Shared run prereqs (workspace/PATH/prompt) | `lib/runPrereqGate.ts` → `enableGate` / `runNowGate` / `lib/integrations/setupGate.ts` |
+| Starting an empty conversation (desktop composer **and** phone) | `lib/startChatGate.ts` (the rules) → `core.startChat` / `core.startRunOptions` |
+| What a paired phone may do, and the routes that enforce it | `lib/mobileScope.ts` (the one allowlist; tags are frozen, widening adds a tag) → `server/mobile/auth.ts` → `server/mobile/handlers.ts`; routes in `routes/api/mobile/**`; the app in the private tree's `ios/` |
 | What "Send test event" sends | `lib/integrations/testEvent.ts` shapes it from the connection's own bindings; `cloud/hosted.ts` `ingestTestEvent` delivers it |
 | Bind address, access token, "who may call this" | `lib/serverAccess.ts` (rules) · `server/accessToken.ts` (values + enforcement) · `src/start.ts` (global middleware) · `scripts/start.ts` (bind) · `SECURITY.md` |
 | Secrets at rest (local DB) | `server/secretBox.ts` (`~/.openrun/data-key`); policy in the private tree's `SECRETS.md` |

--- a/changelog.d/mobile-start-run.md
+++ b/changelog.d/mobile-start-run.md
@@ -1,0 +1,10 @@
+- Your phone is no longer stuck waiting for work someone else started. A paired
+  phone can now open a new run against any worktree the desktop already has,
+  picking the runtime and model the same way the desktop composer does, so an
+  idea away from the keyboard does not have to keep until you are back at it.
+  Workspaces that are busy, quarantined or missing, and runtimes that are not on
+  PATH, are greyed out with the reason the server would have thrown rather than
+  failing after the tap.
+- Starting a run is a new permission, so a phone paired before this release
+  keeps exactly what it was paired with. Devices shows which ones those are and
+  what pairing them again would add.

--- a/src/lib/mobileScope.test.ts
+++ b/src/lib/mobileScope.test.ts
@@ -7,13 +7,45 @@ import {
   type MobileOp,
   isMobileScope,
   mobileScopeAllows,
+  mobileScopeOps,
+  mobileScopeOutdatedHint,
   mobileScopeSummary,
 } from './mobileScope.ts'
 
-test('the control scope grants every declared op', () => {
+test('the current scope grants every declared op', () => {
   for (const op of MOBILE_OPS) {
-    assert.equal(mobileScopeAllows('control', op), true, `expected ${op} allowed`)
+    assert.equal(mobileScopeAllows(DEFAULT_MOBILE_SCOPE, op), true, `expected ${op} allowed`)
   }
+})
+
+test('a shipped tag is frozen — control never gained the ops added after it', () => {
+  // The point of a tag: a phone paired months ago keeps exactly the powers its
+  // owner saw on the pairing screen. Widening adds a tag, it does not edit one.
+  assert.equal(mobileScopeAllows('control', 'runs.create'), false)
+  assert.equal(mobileScopeAllows('control', 'runs.startOptions'), false)
+  // …while everything it did ship with still works.
+  assert.equal(mobileScopeAllows('control', 'approvals.answer'), true)
+  assert.equal(mobileScopeAllows('control', 'tasks.runNow'), true)
+})
+
+test('ops are exposed as ids so a client can feature-detect', () => {
+  assert.deepEqual(mobileScopeOps(DEFAULT_MOBILE_SCOPE), [...MOBILE_OPS])
+  assert.equal(mobileScopeOps('control').includes('runs.create'), false)
+  assert.deepEqual(mobileScopeOps('nope'), [])
+  // A caller mutating the answer must not reach the table behind it.
+  const ops = mobileScopeOps('control')
+  ops.push('runs.create')
+  assert.equal(mobileScopeAllows('control', 'runs.create'), false)
+})
+
+test('an older tag says what pairing again would add', () => {
+  const hint = mobileScopeOutdatedHint('control')
+  assert.ok(hint)
+  assert.match(hint ?? '', /Pair it again/)
+  assert.match(hint ?? '', /start a new run/i)
+  // Current and unknown tags have nothing to explain.
+  assert.equal(mobileScopeOutdatedHint(DEFAULT_MOBILE_SCOPE), null)
+  assert.equal(mobileScopeOutdatedHint('nope'), null)
 })
 
 test('an unknown scope tag denies everything', () => {
@@ -23,10 +55,9 @@ test('an unknown scope tag denies everything', () => {
   }
 })
 
-test('a downgraded build does not honour a scope it does not know', () => {
-  // A device paired by a newer build carries a tag this build has never seen.
-  assert.equal(isMobileScope('control-v2'), false)
-  assert.equal(mobileScopeAllows('control-v2', 'runs.read'), false)
+test('a downgraded build does not honour a tag from the future', () => {
+  assert.equal(isMobileScope('control-v3'), false)
+  assert.equal(mobileScopeAllows('control-v3', 'runs.read'), false)
 })
 
 test('no git, file, project, or settings op is reachable from a phone', () => {
@@ -43,7 +74,7 @@ test('no git, file, project, or settings op is reachable from a phone', () => {
   for (const op of forbidden) {
     // Not in the op list at all, and denied even if someone forces the cast.
     assert.equal(MOBILE_OPS.includes(op as MobileOp), false, `${op} must not be a MobileOp`)
-    assert.equal(mobileScopeAllows('control', op as MobileOp), false)
+    assert.equal(mobileScopeAllows(DEFAULT_MOBILE_SCOPE, op as MobileOp), false)
   }
 })
 
@@ -56,10 +87,11 @@ test('the default scope is a recognised tag', () => {
 })
 
 test('summary labels every granted op and names what is off limits', () => {
-  const { allowed, denied } = mobileScopeSummary('control')
+  const { allowed, denied } = mobileScopeSummary(DEFAULT_MOBILE_SCOPE)
   assert.equal(allowed.length, MOBILE_OPS.length)
   assert.ok(allowed.includes('Allow or deny tool approvals'))
   assert.ok(allowed.includes('Trigger a run now'))
+  assert.ok(allowed.includes('Start a new run in an existing workspace'))
   assert.ok(denied.includes('Commit, push, or open a pull request'))
   assert.ok(denied.includes('Edit runtimes or app settings'))
   // Reading source is in scope; changing it is never.
@@ -67,6 +99,12 @@ test('summary labels every granted op and names what is off limits', () => {
   assert.ok(denied.includes('Write or delete workspace files'))
   // Nothing may be both offered and refused.
   for (const label of allowed) assert.equal(denied.includes(label), false)
+})
+
+test('an older tag summarises the new ops as denied', () => {
+  const { allowed, denied } = mobileScopeSummary('control')
+  assert.equal(allowed.includes('Start a new run in an existing workspace'), false)
+  assert.ok(denied.includes('Start a new run in an existing workspace'))
 })
 
 test('an unknown scope summarises as "allowed nothing"', () => {

--- a/src/lib/mobileScope.ts
+++ b/src/lib/mobileScope.ts
@@ -14,13 +14,20 @@
  * Browser-safe: no `node:` imports.
  */
 
-/** Capability tier granted at pairing time. */
-export type MobileScope = 'control'
+/**
+ * Capability tier granted at pairing time.
+ *
+ * Tags are frozen once shipped. Widening what phones may do adds a *new* tag
+ * rather than editing an old one, so a device paired months ago keeps exactly
+ * the powers its owner saw on the pairing screen until they pair it again.
+ */
+export type MobileScope = 'control' | 'control-v2'
 
 /** Every operation a mobile route can ask for. */
 export type MobileOp =
   // Read
   | 'dashboard'
+  | 'runs.startOptions'
   | 'runs.list'
   | 'runs.read'
   | 'runs.stream'
@@ -29,6 +36,7 @@ export type MobileOp =
   | 'activity.stream'
   | 'tasks.list'
   // Act on a run
+  | 'runs.create'
   | 'runs.cancel'
   | 'runs.message'
   | 'approvals.answer'
@@ -40,6 +48,31 @@ export type MobileOp =
   | 'device.push'
 
 export const MOBILE_OPS: readonly MobileOp[] = [
+  'dashboard',
+  'runs.startOptions',
+  'runs.list',
+  'runs.read',
+  'runs.stream',
+  'runs.diff',
+  'runs.files',
+  'activity.stream',
+  'tasks.list',
+  'runs.create',
+  'runs.cancel',
+  'runs.message',
+  'approvals.answer',
+  'tasks.toggle',
+  'tasks.runNow',
+  'device.unpair',
+  'device.push',
+]
+
+/**
+ * Ops the original `control` tag shipped with. Written out rather than derived
+ * by subtraction: a frozen tag must not quietly change shape the next time an
+ * op is added to `MOBILE_OPS`.
+ */
+const CONTROL_OPS: readonly MobileOp[] = [
   'dashboard',
   'runs.list',
   'runs.read',
@@ -60,10 +93,17 @@ export const MOBILE_OPS: readonly MobileOp[] = [
 /**
  * Ops granted by each scope tag.
  *
- * `control` is monitor + review + approve + automation on/off + Run now. It
- * deliberately excludes everything that edits configuration or writes to a
- * repo: a phone token travels over the LAN in cleartext, so its blast radius is
- * capped at things that are visible and reversible from the desktop.
+ * `control` is monitor + review + approve + automation on/off + Run now.
+ * `control-v2` adds starting a new chat in an existing workspace — the same
+ * class of power `tasks.runNow` and `runs.message` already carry (spawn an
+ * agent, hand it a prompt), not a new one, but a widening all the same, so it
+ * rides on its own tag and a phone paired before it stays on `control` until
+ * it is paired again.
+ *
+ * Both tiers deliberately exclude everything that edits configuration or
+ * writes to a repo: a phone token travels over the LAN in cleartext, so its
+ * blast radius is capped at things that are visible and reversible from the
+ * desktop.
  *
  * `runs.diff` / `runs.files` are read-only by construction — they reach
  * `core.getFileDiff` / `core.listWorkspaceFiles` / `core.readWorkspaceFile` and
@@ -71,14 +111,41 @@ export const MOBILE_OPS: readonly MobileOp[] = [
  * an untrusted network wants the https tunnel, not the LAN address.
  */
 const SCOPE_OPS: Record<MobileScope, readonly MobileOp[]> = {
-  control: MOBILE_OPS,
+  control: CONTROL_OPS,
+  'control-v2': MOBILE_OPS,
 }
 
-export const DEFAULT_MOBILE_SCOPE: MobileScope = 'control'
+export const DEFAULT_MOBILE_SCOPE: MobileScope = 'control-v2'
 
 /** True when `scope` is a tag this build understands. */
 export function isMobileScope(value: string): value is MobileScope {
   return Object.hasOwn(SCOPE_OPS, value)
+}
+
+/**
+ * The op ids a scope tag grants, for a client that needs to *feature-detect*
+ * rather than read prose. The phone hides a control it may not use instead of
+ * offering a button that comes back 403.
+ *
+ * An unrecognised tag grants nothing, same as `mobileScopeAllows`.
+ */
+export function mobileScopeOps(scope: string): MobileOp[] {
+  if (!isMobileScope(scope)) return []
+  return [...SCOPE_OPS[scope]]
+}
+
+/**
+ * What a paired device is missing because it holds an older tag, or `null`
+ * when it is current. Shown on the desktop Devices page so "why can't my phone
+ * do that" has an answer that is not "read the source".
+ */
+export function mobileScopeOutdatedHint(scope: string): string | null {
+  if (!isMobileScope(scope) || scope === DEFAULT_MOBILE_SCOPE) return null
+  const missing = MOBILE_OPS.filter((op) => !SCOPE_OPS[scope].includes(op))
+  if (missing.length === 0) return null
+  return `Paired before this build. Pair it again to add: ${missing
+    .map((op) => OP_LABELS[op].toLowerCase())
+    .join(', ')}.`
 }
 
 /**
@@ -95,6 +162,7 @@ export function mobileScopeAllows(scope: string, op: MobileOp): boolean {
 /** User-facing label per op, for the "what your phone can do" panel. */
 const OP_LABELS: Record<MobileOp, string> = {
   dashboard: 'See the dashboard',
+  'runs.startOptions': 'See which workspaces and runtimes can take a run',
   'runs.list': 'Browse run history',
   'runs.read': 'Read a run transcript',
   'runs.stream': 'Watch run output live',
@@ -102,6 +170,7 @@ const OP_LABELS: Record<MobileOp, string> = {
   'runs.files': 'Read workspace files (read-only)',
   'activity.stream': 'Get live run activity',
   'tasks.list': 'Browse automations',
+  'runs.create': 'Start a new run in an existing workspace',
   'runs.cancel': 'Cancel a running run',
   'runs.message': 'Send a chat follow-up',
   'approvals.answer': 'Allow or deny tool approvals',

--- a/src/lib/startChatGate.test.ts
+++ b/src/lib/startChatGate.test.ts
@@ -1,0 +1,110 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import {
+  canStartChat,
+  emptyChatPromptMessage,
+  missingRuntimeMessage,
+  runtimeStartBlockedReason,
+  startChatBlockedReason,
+  workspaceBusyMessage,
+  workspaceStartBlockedReason,
+  type StartChatGateInput,
+} from './startChatGate.ts'
+import type { WorkspaceHealth } from './workspaceHealth.ts'
+
+const health = (over: Partial<WorkspaceHealth> = {}): WorkspaceHealth => ({
+  code: 'ok',
+  path: '/tmp/ws',
+  configuredBranch: 'feat/x',
+  actualBranch: 'feat/x',
+  dirty: false,
+  detail: '',
+  ...over,
+})
+
+const green = (over: Partial<StartChatGateInput> = {}): StartChatGateInput => ({
+  workspaceValid: true,
+  workspaceReady: true,
+  workspaceStatus: 'ready',
+  workspaceHealth: health(),
+  activeRunId: null,
+  runtimeValid: true,
+  runtimeInstalled: true,
+  runtimeBin: 'claude',
+  promptValid: true,
+  ...over,
+})
+
+test('a ready workspace, an installed runtime and a prompt may start', () => {
+  assert.equal(startChatBlockedReason(green()), null)
+  assert.equal(canStartChat(green()), true)
+})
+
+test('a missing workspace refuses before anything else is inspected', () => {
+  const reason = startChatBlockedReason(
+    green({ workspaceValid: false, runtimeInstalled: false, promptValid: false }),
+  )
+  assert.match(reason ?? '', /Pick a repository/)
+})
+
+test('a workspace that is not ready refuses with its lifecycle reason', () => {
+  const reason = startChatBlockedReason(
+    green({ workspaceReady: false, workspaceStatus: 'creating' }),
+  )
+  assert.match(reason ?? '', /still being set up/)
+})
+
+test('a workspace whose directory is gone refuses', () => {
+  const reason = startChatBlockedReason(green({ workspaceHealth: health({ code: 'missing' }) }))
+  assert.ok(reason)
+})
+
+test('a busy worktree refuses with the words assertWorkspaceFree throws', () => {
+  assert.equal(startChatBlockedReason(green({ activeRunId: 'run_1' })), workspaceBusyMessage())
+  // Whitespace is not a run.
+  assert.equal(startChatBlockedReason(green({ activeRunId: '  ' })), null)
+})
+
+test('busy beats a runtime or prompt problem — the worktree is the harder no', () => {
+  const reason = startChatBlockedReason(
+    green({ activeRunId: 'run_1', runtimeInstalled: false, promptValid: false }),
+  )
+  assert.equal(reason, workspaceBusyMessage())
+})
+
+test('an unresolved runtime refuses before PATH is consulted', () => {
+  assert.equal(
+    startChatBlockedReason(green({ runtimeValid: false, runtimeInstalled: false })),
+    missingRuntimeMessage(),
+  )
+})
+
+test('a runtime off PATH names the binary', () => {
+  const reason = startChatBlockedReason(green({ runtimeInstalled: false, runtimeBin: 'codex' }))
+  assert.match(reason ?? '', /"codex" was not found on PATH/)
+})
+
+test('an empty first message is the last thing to refuse', () => {
+  assert.equal(startChatBlockedReason(green({ promptValid: false })), emptyChatPromptMessage())
+  assert.equal(canStartChat(green({ promptValid: false })), false)
+})
+
+test('the halves judge only their own row', () => {
+  // A picker greys out the workspace, not the runtime, when the worktree is busy.
+  assert.equal(workspaceStartBlockedReason(green({ activeRunId: 'run_1' })), workspaceBusyMessage())
+  assert.equal(runtimeStartBlockedReason(green({ activeRunId: 'run_1' })), null)
+
+  // …and the runtime, not the workspace, when the CLI is missing.
+  assert.equal(workspaceStartBlockedReason(green({ runtimeInstalled: false })), null)
+  assert.ok(runtimeStartBlockedReason(green({ runtimeInstalled: false })))
+})
+
+test('a dirty worktree is a human judgement call, not a refusal', () => {
+  // Attended work in a tree with uncommitted changes is normal; only the
+  // unattended gate treats contamination as fatal.
+  assert.equal(
+    startChatBlockedReason(green({ workspaceHealth: health({ code: 'dirty', dirty: true }) })),
+    null,
+  )
+})

--- a/src/lib/startChatGate.ts
+++ b/src/lib/startChatGate.ts
@@ -1,0 +1,87 @@
+/**
+ * Why "Start a run" would refuse — the shared rule module behind an empty
+ * conversation, wherever it is started from.
+ *
+ * Mirrors `core.startChat` → `executor.startRun` in the order those refuse:
+ * the workspace exists → is ready → is physically fit → is not already busy,
+ * then the runtime resolves → is on PATH, then there is a first message. A
+ * caller that renders one of these sentences is showing the words the server
+ * would have thrown after the tap, not a second opinion about them.
+ *
+ * The two halves are exported separately because a picker needs them
+ * separately: a workspace row can be unusable on its own (busy, quarantined)
+ * and a runtime row can be unusable on its own (not installed), and a list has
+ * to grey out the right one.
+ *
+ * Browser-safe and dependency-free like everything in `lib/`.
+ */
+import { missingRuntimeBinaryMessage } from './runtimeBinary.ts'
+import { workspaceBlockedReason, type WorkspaceGateInput } from './runPrereqGate.ts'
+
+/** A workspace row, as far as starting a run is concerned. */
+export type WorkspaceStartInput = WorkspaceGateInput & {
+  /** id of a run already holding this worktree; empty / null when free. */
+  activeRunId?: string | null
+}
+
+/** A runtime row, as far as starting a run is concerned. */
+export type RuntimeStartInput = {
+  /** False when the chosen runtime id no longer resolves to a row. */
+  runtimeValid: boolean
+  runtimeInstalled: boolean
+  /** Trimmed binary name, for the PATH-missing copy. */
+  runtimeBin?: string
+}
+
+export type StartChatGateInput = WorkspaceStartInput &
+  RuntimeStartInput & {
+    /** False when the composer is empty or whitespace-only. */
+    promptValid: boolean
+  }
+
+/** What `assertWorkspaceFree` throws. */
+export function workspaceBusyMessage(): string {
+  return 'This workspace already has a run in progress'
+}
+
+/** What `startChat` throws when the runtime id does not resolve. */
+export function missingRuntimeMessage(): string {
+  return 'Runtime not found'
+}
+
+/** What `startChat` throws on an empty opening message. */
+export function emptyChatPromptMessage(): string {
+  return 'A first message is required'
+}
+
+/** Reason this workspace cannot take a new run, or `null` when it can. */
+export function workspaceStartBlockedReason(input: WorkspaceStartInput): string | null {
+  const workspace = workspaceBlockedReason(input)
+  if (workspace) return workspace
+  if ((input.activeRunId ?? '').trim().length > 0) return workspaceBusyMessage()
+  return null
+}
+
+/** Reason this runtime cannot take a new run, or `null` when it can. */
+export function runtimeStartBlockedReason(input: RuntimeStartInput): string | null {
+  if (!input.runtimeValid) return missingRuntimeMessage()
+  if (!input.runtimeInstalled) return missingRuntimeBinaryMessage(input.runtimeBin ?? '')
+  return null
+}
+
+/**
+ * Reason starting a chat would refuse, in the server's own order, or `null`
+ * when the composer may send.
+ */
+export function startChatBlockedReason(input: StartChatGateInput): string | null {
+  return (
+    workspaceStartBlockedReason(input) ??
+    runtimeStartBlockedReason(input) ??
+    (input.promptValid ? null : emptyChatPromptMessage())
+  )
+}
+
+/** True when a new run may start. */
+export function canStartChat(input: StartChatGateInput): boolean {
+  return startChatBlockedReason(input) === null
+}

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -31,6 +31,7 @@ import { Route as ApiActivityStreamRouteImport } from './routes/api/activity/str
 import { Route as ApiMobileDashboardRouteImport } from './routes/api/mobile/dashboard'
 import { Route as ApiMobileMeRouteImport } from './routes/api/mobile/me'
 import { Route as ApiMobilePairRouteImport } from './routes/api/mobile/pair'
+import { Route as ApiMobileStartOptionsRouteImport } from './routes/api/mobile/start-options'
 import { Route as ApiMobileUnpairRouteImport } from './routes/api/mobile/unpair'
 import { Route as ApiMcpOauthCallbackRouteImport } from './routes/api/mcp/oauth/callback'
 import { Route as ApiMobileActivityStreamRouteImport } from './routes/api/mobile/activity.stream'
@@ -160,6 +161,11 @@ const ApiMobileMeRoute = ApiMobileMeRouteImport.update({
 const ApiMobilePairRoute = ApiMobilePairRouteImport.update({
   id: '/api/mobile/pair',
   path: '/api/mobile/pair',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiMobileStartOptionsRoute = ApiMobileStartOptionsRouteImport.update({
+  id: '/api/mobile/start-options',
+  path: '/api/mobile/start-options',
   getParentRoute: () => rootRouteImport,
 } as any)
 const ApiMobileUnpairRoute = ApiMobileUnpairRouteImport.update({
@@ -293,6 +299,7 @@ export interface FileRoutesByFullPath {
   '/api/mobile/dashboard': typeof ApiMobileDashboardRoute
   '/api/mobile/me': typeof ApiMobileMeRoute
   '/api/mobile/pair': typeof ApiMobilePairRoute
+  '/api/mobile/start-options': typeof ApiMobileStartOptionsRoute
   '/api/mobile/unpair': typeof ApiMobileUnpairRoute
   '/api/mcp/oauth/callback': typeof ApiMcpOauthCallbackRoute
   '/api/mobile/activity/stream': typeof ApiMobileActivityStreamRoute
@@ -336,6 +343,7 @@ export interface FileRoutesByTo {
   '/api/mobile/dashboard': typeof ApiMobileDashboardRoute
   '/api/mobile/me': typeof ApiMobileMeRoute
   '/api/mobile/pair': typeof ApiMobilePairRoute
+  '/api/mobile/start-options': typeof ApiMobileStartOptionsRoute
   '/api/mobile/unpair': typeof ApiMobileUnpairRoute
   '/api/mcp/oauth/callback': typeof ApiMcpOauthCallbackRoute
   '/api/mobile/activity/stream': typeof ApiMobileActivityStreamRoute
@@ -381,6 +389,7 @@ export interface FileRoutesById {
   '/api/mobile/dashboard': typeof ApiMobileDashboardRoute
   '/api/mobile/me': typeof ApiMobileMeRoute
   '/api/mobile/pair': typeof ApiMobilePairRoute
+  '/api/mobile/start-options': typeof ApiMobileStartOptionsRoute
   '/api/mobile/unpair': typeof ApiMobileUnpairRoute
   '/api/mcp/oauth/callback': typeof ApiMcpOauthCallbackRoute
   '/api/mobile/activity/stream': typeof ApiMobileActivityStreamRoute
@@ -427,6 +436,7 @@ export interface FileRouteTypes {
     | '/api/mobile/dashboard'
     | '/api/mobile/me'
     | '/api/mobile/pair'
+    | '/api/mobile/start-options'
     | '/api/mobile/unpair'
     | '/api/mcp/oauth/callback'
     | '/api/mobile/activity/stream'
@@ -470,6 +480,7 @@ export interface FileRouteTypes {
     | '/api/mobile/dashboard'
     | '/api/mobile/me'
     | '/api/mobile/pair'
+    | '/api/mobile/start-options'
     | '/api/mobile/unpair'
     | '/api/mcp/oauth/callback'
     | '/api/mobile/activity/stream'
@@ -514,6 +525,7 @@ export interface FileRouteTypes {
     | '/api/mobile/dashboard'
     | '/api/mobile/me'
     | '/api/mobile/pair'
+    | '/api/mobile/start-options'
     | '/api/mobile/unpair'
     | '/api/mcp/oauth/callback'
     | '/api/mobile/activity/stream'
@@ -557,6 +569,7 @@ export interface RootRouteChildren {
   ApiMobileDashboardRoute: typeof ApiMobileDashboardRoute
   ApiMobileMeRoute: typeof ApiMobileMeRoute
   ApiMobilePairRoute: typeof ApiMobilePairRoute
+  ApiMobileStartOptionsRoute: typeof ApiMobileStartOptionsRoute
   ApiMobileUnpairRoute: typeof ApiMobileUnpairRoute
   ApiMcpOauthCallbackRoute: typeof ApiMcpOauthCallbackRoute
   ApiMobileActivityStreamRoute: typeof ApiMobileActivityStreamRoute
@@ -731,6 +744,13 @@ declare module '@tanstack/react-router' {
       path: '/api/mobile/pair'
       fullPath: '/api/mobile/pair'
       preLoaderRoute: typeof ApiMobilePairRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/mobile/start-options': {
+      id: '/api/mobile/start-options'
+      path: '/api/mobile/start-options'
+      fullPath: '/api/mobile/start-options'
+      preLoaderRoute: typeof ApiMobileStartOptionsRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/api/mobile/unpair': {
@@ -939,6 +959,7 @@ const rootRouteChildren: RootRouteChildren = {
   ApiMobileDashboardRoute: ApiMobileDashboardRoute,
   ApiMobileMeRoute: ApiMobileMeRoute,
   ApiMobilePairRoute: ApiMobilePairRoute,
+  ApiMobileStartOptionsRoute: ApiMobileStartOptionsRoute,
   ApiMobileUnpairRoute: ApiMobileUnpairRoute,
   ApiMcpOauthCallbackRoute: ApiMcpOauthCallbackRoute,
   ApiMobileActivityStreamRoute: ApiMobileActivityStreamRoute,

--- a/src/routes/api/mobile/runs/index.ts
+++ b/src/routes/api/mobile/runs/index.ts
@@ -1,7 +1,15 @@
-/** Run history, newest first. Page size is clamped server-side. */
+/**
+ * Run history, newest first (page size is clamped server-side), and starting a
+ * new one.
+ *
+ * POST refuses with 409 and the server's own reason when the worktree is
+ * missing, not ready, quarantined or already busy, when the runtime binary is
+ * off PATH, or when the first message is empty — the same order
+ * `lib/startChatGate.ts` mirrors for the desktop composer.
+ */
 import { createFileRoute } from '@tanstack/react-router'
 import { requireDeviceOp } from '#/server/mobile/auth'
-import { handleListRuns } from '#/server/mobile/handlers'
+import { handleListRuns, handleStartChat, readJson } from '#/server/mobile/handlers'
 
 export const Route = createFileRoute('/api/mobile/runs/')({
   server: {
@@ -10,6 +18,12 @@ export const Route = createFileRoute('/api/mobile/runs/')({
         const auth = requireDeviceOp(request, 'runs.list')
         if (!auth.ok) return Response.json(auth.body, { status: auth.status })
         const result = await handleListRuns(new URL(request.url))
+        return Response.json(result.body, { status: result.status })
+      },
+      POST: async ({ request }) => {
+        const auth = requireDeviceOp(request, 'runs.create')
+        if (!auth.ok) return Response.json(auth.body, { status: auth.status })
+        const result = await handleStartChat(await readJson(request))
         return Response.json(result.body, { status: result.status })
       },
     },

--- a/src/routes/api/mobile/start-options.ts
+++ b/src/routes/api/mobile/start-options.ts
@@ -1,0 +1,20 @@
+/**
+ * What a new run could be started against: the worktrees that could host one
+ * and the runtimes that could drive it, each with the reason it cannot.
+ */
+import { createFileRoute } from '@tanstack/react-router'
+import { requireDeviceOp } from '#/server/mobile/auth'
+import { handleStartOptions } from '#/server/mobile/handlers'
+
+export const Route = createFileRoute('/api/mobile/start-options')({
+  server: {
+    handlers: {
+      GET: async ({ request }) => {
+        const auth = requireDeviceOp(request, 'runs.startOptions')
+        if (!auth.ok) return Response.json(auth.body, { status: auth.status })
+        const result = await handleStartOptions()
+        return Response.json(result.body, { status: result.status })
+      },
+    },
+  },
+})

--- a/src/routes/devices.tsx
+++ b/src/routes/devices.tsx
@@ -13,6 +13,7 @@ import QRCode from 'qrcode'
 
 import { Button, Card, EmptyState, Modal, PageHeader } from '../components/ui'
 import { relativeTime } from '../lib/format'
+import { mobileScopeOutdatedHint } from '../lib/mobileScope'
 import { encodePairingQr, formatPairingCode } from '../lib/pairing'
 import {
   useCancelPairing,
@@ -227,6 +228,9 @@ function ReachabilityCard({
 }
 
 function DeviceRow({ device, onRevoke }: { device: DeviceLike; onRevoke: () => void }) {
+  // A phone paired by an older build keeps the powers it was paired with. Say
+  // so here rather than letting the missing button read as a bug.
+  const outdated = mobileScopeOutdatedHint(device.scope)
   return (
     <li className="flex items-center gap-3 border-b border-border px-4 py-3 last:border-b-0">
       <Smartphone className="size-4 shrink-0 text-tier-tertiary" />
@@ -237,6 +241,7 @@ function DeviceRow({ device, onRevoke }: { device: DeviceLike; onRevoke: () => v
           {device.lastSeenAt ? ` · last seen ${relativeTime(device.lastSeenAt)}` : ''}
           {device.pushToken ? ' · push on' : ' · push off'}
         </div>
+        {outdated ? <div className="mt-1 text-ui-sm text-tier-tertiary">{outdated}</div> : null}
       </div>
       <Button variant="danger" onClick={onRevoke}>
         Revoke

--- a/src/server/core.ts
+++ b/src/server/core.ts
@@ -27,8 +27,20 @@ import {
 } from '../lib/unattendedGate.ts'
 import { workspaceHealthBlockedReason, type WorkspaceHealth } from '../lib/workspaceHealth.ts'
 import { assertWorkspaceReady, isWorkspaceReady } from '../lib/workspaceReady'
+import {
+  emptyChatPromptMessage,
+  missingRuntimeMessage,
+  runtimeStartBlockedReason,
+  workspaceStartBlockedReason,
+} from '../lib/startChatGate'
 import { parsePlanProposals, type PlanProposal } from '../lib/planProposals'
-import { defaultEffort, defaultModel, findModel, type ModelOption } from '../lib/models'
+import {
+  defaultEffort,
+  defaultModel,
+  findModel,
+  modelsForRuntime,
+  type ModelOption,
+} from '../lib/models'
 import { cachedModelsForBin, warmModelCatalogs } from './modelCatalog'
 import { parseRuntimeMode } from '../lib/runtimeMode'
 import { compareRuntimesForDisplay, RUNTIME_PRESETS } from '../lib/runtimePresets'
@@ -1554,6 +1566,96 @@ export function getLatestRunForProject(projectId: string): { id: string } | null
 }
 
 /** Start an ad-hoc chat run in a workspace — no task/automation required. */
+/**
+ * Everything a picker needs to open an empty conversation: the worktrees that
+ * could host it and the runtimes that could drive it, each carrying the reason
+ * it cannot — from `lib/startChatGate.ts`, so a greyed-out row explains itself
+ * with the sentence `startChat` would have thrown.
+ *
+ * Archived workspaces and disabled runtimes are dropped rather than listed as
+ * blocked: they are not choices a user is weighing, they are gone.
+ */
+export type StartRunWorkspaceOption = {
+  id: string
+  projectId: string
+  projectName: string
+  name: string
+  branch: string
+  kind: 'main' | 'worktree'
+  status: 'creating' | 'ready' | 'error' | 'archived'
+  /** Set while another run holds this worktree. */
+  activeRunId: string | null
+  blockedReason: string | null
+}
+
+export type StartRunRuntimeOption = {
+  id: string
+  label: string
+  bin: string
+  transport: string
+  installed: boolean
+  models: ModelOption[]
+  /** Slug the composer should preselect; empty when the catalog is empty. */
+  defaultModel: string
+  defaultEffort: string
+  blockedReason: string | null
+}
+
+export function startRunOptions(): {
+  workspaces: StartRunWorkspaceOption[]
+  runtimes: StartRunRuntimeOption[]
+} {
+  const workspaces = listWorkspaces()
+    .filter((workspace) => workspace.status !== 'archived')
+    .map((workspace) => {
+      // Read, never repair: `decorate` documents why drawing a list must not
+      // demote a row, and the same holds here.
+      const health = cachedWorkspaceHealth(workspace)
+      return {
+        id: workspace.id,
+        projectId: workspace.projectId,
+        projectName: workspace.projectName,
+        name: workspace.name,
+        branch: workspace.actualBranch || workspace.branch,
+        kind: workspace.kind,
+        status: workspace.status,
+        activeRunId: workspace.activeRunId,
+        blockedReason: workspaceStartBlockedReason({
+          workspaceValid: true,
+          workspaceReady: isWorkspaceReady(workspace.status),
+          workspaceStatus: workspace.status,
+          workspaceHealth: health,
+          activeRunId: workspace.activeRunId,
+        }),
+      }
+    })
+
+  const runtimes = listRuntimes()
+    .filter((runtime) => runtime.enabled === 1)
+    .map((runtime) => {
+      const installed = checkRuntimeInstalled(runtime.bin).installed
+      const models = modelsForRuntime(runtime)
+      const preselected = defaultModel(models)
+      return {
+        id: runtime.id,
+        label: runtime.label,
+        bin: runtime.bin,
+        transport: runtime.transport,
+        installed,
+        models,
+        defaultModel: preselected?.slug ?? '',
+        defaultEffort: defaultEffort(preselected),
+        blockedReason: runtimeStartBlockedReason({
+          runtimeValid: true,
+          runtimeInstalled: installed,
+          runtimeBin: runtime.bin,
+        }),
+      }
+    })
+
+  return { workspaces, runtimes }
+}
+
 export function startChat(input: {
   workspaceId: string
   runtimeId: string
@@ -1568,10 +1670,10 @@ export function startChat(input: {
   if (!workspace) throw new Error('Workspace not found')
   assertWorkspaceReady(workspace.status)
   const prompt = input.prompt.trim()
-  if (!prompt) throw new Error('A first message is required')
+  if (!prompt) throw new Error(emptyChatPromptMessage())
 
   const runtime = getRuntime(input.runtimeId)
-  if (!runtime) throw new Error('Runtime not found')
+  if (!runtime) throw new Error(missingRuntimeMessage())
 
   const runId = startRun({
     runtime,

--- a/src/server/mobile/handlers.ts
+++ b/src/server/mobile/handlers.ts
@@ -10,11 +10,17 @@
  *    `readWorkspaceFile`). There is no code path from a phone to a commit, a
  *    push, or a file write, whatever a token claims.
  *
+ * Starting a run is the one write that reaches an agent. It is the same power
+ * `tasks.runNow` and `runs.message` already carry — spawn a CLI in a worktree
+ * the desktop already created, hand it a prompt — and it still cannot create a
+ * workspace, a project, or an automation to point at.
+ *
  * Core throws on bad input; the boundary converts that into a status.
  */
 import { pendingApprovals } from '../../lib/pendingApprovals'
-import { mobileScopeSummary } from '../../lib/mobileScope'
+import { mobileScopeOps, mobileScopeSummary } from '../../lib/mobileScope'
 import { runNowBlockedReason } from '../../lib/runNowGate'
+import { startChatBlockedReason } from '../../lib/startChatGate'
 import type { DeviceRow } from '../db'
 import { clearPairAttempts, pairAttemptBlocked, recordPairFailure, RATE_LIMITED } from './auth'
 import { redeemPairingCode, registerPushToken, revokeDevice } from './devices'
@@ -105,12 +111,20 @@ export async function handlePair(input: {
   return ok({
     token: result.token,
     device: publicDevice(result.device),
-    scope: mobileScopeSummary(result.device.scope),
+    scope: {
+      ...mobileScopeSummary(result.device.scope),
+      // Op ids, not prose: a client hides a control it may not use, and
+      // matching on a human label would break the first time one is reworded.
+      ops: mobileScopeOps(result.device.scope),
+    },
   })
 }
 
 export async function handleMe(device: DeviceRow): Promise<MobileResult> {
-  return ok({ device: publicDevice(device), scope: mobileScopeSummary(device.scope) })
+  return ok({
+    device: publicDevice(device),
+    scope: { ...mobileScopeSummary(device.scope), ops: mobileScopeOps(device.scope) },
+  })
 }
 
 export async function handleRegisterPush(input: {
@@ -259,6 +273,15 @@ export async function handleRunFileContent(input: {
   }
 }
 
+/**
+ * What a new run could be started against. Prompts are never sent here — the
+ * phone composes its own — and archived workspaces / disabled runtimes are
+ * already dropped by `core.startRunOptions`.
+ */
+export async function handleStartOptions(): Promise<MobileResult> {
+  return ok({ ...(await core()).startRunOptions() })
+}
+
 export async function handleListTasks(): Promise<MobileResult> {
   // Strip the prompt: it can be long, and the phone cannot edit it anyway.
   const tasks = (await core()).listTasks().map((task) => ({
@@ -286,6 +309,59 @@ export async function handleListTasks(): Promise<MobileResult> {
 // ---------------------------------------------------------------------------
 // Writes — the narrow set a phone may perform
 // ---------------------------------------------------------------------------
+
+/**
+ * Open an empty conversation in an existing workspace.
+ *
+ * Deliberately narrower than the desktop composer: no workspace is created, no
+ * native CLI chat is adopted, and supervised mode is not selectable — a phone
+ * cannot create the thing it would be starting a run against, and a supervised
+ * run started from a phone that then backgrounds is a five-minute auto-deny
+ * waiting to happen.
+ */
+export async function handleStartChat(body: Record<string, unknown> | null): Promise<MobileResult> {
+  const workspaceId = str(body, 'workspaceId')
+  const runtimeId = str(body, 'runtimeId')
+  const prompt = str(body, 'prompt')
+  if (!workspaceId) {
+    return { ok: false, status: 400, body: { error: 'A workspaceId is required.' } }
+  }
+  if (!runtimeId) {
+    return { ok: false, status: 400, body: { error: 'A runtimeId is required.' } }
+  }
+
+  // Refuse with the gate's words before touching the executor, so a stale
+  // picker gets the same sentence the phone would have rendered on the row.
+  const options = (await core()).startRunOptions()
+  const workspace = options.workspaces.find((candidate) => candidate.id === workspaceId)
+  const runtime = options.runtimes.find((candidate) => candidate.id === runtimeId)
+  const blocked = startChatBlockedReason({
+    workspaceValid: Boolean(workspace),
+    workspaceReady: workspace?.status === 'ready',
+    workspaceStatus: workspace?.status ?? null,
+    activeRunId: workspace?.activeRunId ?? null,
+    runtimeValid: Boolean(runtime),
+    runtimeInstalled: runtime?.installed ?? false,
+    runtimeBin: runtime?.bin,
+    promptValid: prompt.trim().length > 0,
+  })
+  if (blocked) return { ok: false, status: 409, body: { error: blocked } }
+
+  try {
+    const started = (await core()).startChat({
+      workspaceId,
+      runtimeId,
+      prompt,
+      model: str(body, 'model') || undefined,
+      effort: str(body, 'effort') || undefined,
+    })
+    return ok({ ...started })
+  } catch (err) {
+    // Anything left is a race the gate could not see — the worktree was taken
+    // between the check and the start, or the CLI left PATH.
+    return failed(err, 409)
+  }
+}
 
 export async function handleCancelRun(runId: string): Promise<MobileResult> {
   if (!(await core()).getRun(runId)) return NOT_FOUND

--- a/src/server/workspaces.ts
+++ b/src/server/workspaces.ts
@@ -45,6 +45,7 @@ import {
 } from '../lib/checks'
 import { assertFolderName } from '../lib/folderName'
 import { assertWorkspaceReady } from '../lib/workspaceReady'
+import { workspaceBusyMessage } from '../lib/startChatGate.ts'
 import { missingWorkspaceDirMessage } from '../lib/workspaceHealth.ts'
 import {
   openrunHome,
@@ -863,12 +864,12 @@ export function resolveWorkspacePath(workspaceId: string): string {
  */
 export function assertWorkspaceFree(workspaceId: string): void {
   if (isWorkspaceCancellationPending(workspaceId)) {
-    throw new Error('This workspace already has a run in progress')
+    throw new Error(workspaceBusyMessage())
   }
   const active = getDb()
     .prepare("SELECT id FROM runs WHERE workspaceId = ? AND status = 'running'")
     .get(workspaceId) as { id: string } | undefined
   if (active) {
-    throw new Error('This workspace already has a run in progress')
+    throw new Error(workspaceBusyMessage())
   }
 }


### PR DESCRIPTION
## Summary
- A paired phone can now open a new run against a worktree the desktop already has, picking the runtime and model the way the desktop composer does. Until now the phone could drive an agent — Run now, follow-ups, approvals — but only after someone at the Mac opened the conversation.
- Worktrees that are busy, quarantined, archived or missing, and runtimes off PATH, come back with the reason `startChat` would have thrown, so a picker greys the right row out instead of failing after the tap. `lib/startChatGate.ts` is the one place those rules live; `assertWorkspaceFree` and `startChat` now throw its sentences rather than their own copies.
- Starting a run is a widening, so it rides on a new scope tag (`control-v2`) instead of editing the one existing devices hold. A phone paired before this keeps exactly what it was paired with, and Devices says what pairing it again would add.
- `/pair` and `/me` now also return the granted op **ids**, so a client can hide a control it may not use rather than matching on a human-readable label.

## Test plan
- [ ] `AGENTOPS_MOBILE=1 pnpm dev`, pair a phone from Devices, and confirm the pairing screen lists "Start a new run in an existing workspace" under what the phone may do.
- [ ] `curl -H "Authorization: Bearer $TOKEN" localhost:3000/api/mobile/start-options` — every non-archived worktree and enabled runtime, each with `blockedReason` null or a sentence.
- [ ] `POST /api/mobile/runs` with `workspaceId`, `runtimeId` and `prompt` starts a chat that appears at `/runs` on the desktop and streams live.
- [ ] Start a run on the desktop in a worktree, then POST against that same worktree from the phone: 409 with "This workspace already has a run in progress".
- [ ] Point `runtimeId` at a runtime whose binary is not on PATH: 409 naming the binary.
- [ ] POST with an empty `prompt`: 409 with "A first message is required".
- [ ] On a device row paired by the previous build (scope `control`), Devices shows the "Pair it again to add…" line, and `POST /api/mobile/runs` returns 403 listing what the device may do.

The iOS client for this is a separate PR on `openrun-internal`; it is unbuilt there (no Xcode in that environment) and needs a device run before either lands.