### PR TITLE
feat(runs): show workspace picker on start page

### DIFF
--- a/changelog.d/homepage-project-picker.md
+++ b/changelog.d/homepage-project-picker.md
@@ -1,0 +1,3 @@
+You no longer have to guess which project and branch a chat started from the
+home page will use. The selected workspace is shown above the composer, where
+you can switch projects or branches before sending the first message.

--- a/src/components/NewRunSurface.tsx
+++ b/src/components/NewRunSurface.tsx
@@ -13,9 +13,17 @@ import { NewWorkspaceModal } from './NewWorkspaceModal'
 import { WorkspaceBreadcrumb } from './workspace/WorkspaceBreadcrumb'
 import type { NewRunDraft } from '../hooks/useNewRunDraft'
 
-export function NewRunBreadcrumb({ draft }: { draft: NewRunDraft }) {
+export function NewRunBreadcrumb({
+  draft,
+  compact = false,
+}: {
+  draft: NewRunDraft
+  compact?: boolean
+}) {
   return (
     <WorkspaceBreadcrumb
+      className={compact ? 'text-[10px]' : undefined}
+      muted={compact}
       projectId={draft.projectId}
       projectName={draft.project?.name}
       workspace={draft.workspace}

--- a/src/components/workspace/NavigationPicker.tsx
+++ b/src/components/workspace/NavigationPicker.tsx
@@ -127,12 +127,14 @@ export function NavigationProjectPicker({
   projects,
   projectId,
   disabled,
+  muted,
   onChange,
   onAddProject,
 }: {
   projects: NavigationProject[]
   projectId: string
   disabled?: boolean
+  muted?: boolean
   onChange: (id: string) => void
   onAddProject?: () => void
 }) {
@@ -143,6 +145,7 @@ export function NavigationProjectPicker({
       title={selected?.path ?? selected?.name ?? 'Select repository'}
       icon={<FolderGit2 className="h-3.5 w-3.5 shrink-0 text-muted-foreground/60" />}
       disabled={disabled}
+      muted={muted}
     >
       {(close) => (
         <>

--- a/src/components/workspace/WorkspaceBreadcrumb.tsx
+++ b/src/components/workspace/WorkspaceBreadcrumb.tsx
@@ -115,6 +115,7 @@ function BranchSwitcher({
 }
 
 export function WorkspaceBreadcrumb({
+  className = '',
   projectId,
   projectName,
   branch,
@@ -124,11 +125,13 @@ export function WorkspaceBreadcrumb({
   workspace,
   workspaces,
   branchDisabled,
+  muted = false,
   onRequestNewBranch,
   onAddProject,
   onSelectProject,
   onSelectWorkspace,
 }: {
+  className?: string
   projectId?: string
   projectName?: string
   branch?: string
@@ -138,6 +141,7 @@ export function WorkspaceBreadcrumb({
   workspace?: WorkspaceWithMeta | null
   workspaces?: WorkspaceWithMeta[]
   branchDisabled?: boolean
+  muted?: boolean
   onRequestNewBranch?: () => void
   onAddProject?: () => void
   onSelectProject?: (projectId: string) => void
@@ -172,13 +176,17 @@ export function WorkspaceBreadcrumb({
   }
 
   return (
-    <nav aria-label="Breadcrumb" className="flex min-w-0 flex-1 items-center gap-1.5 text-[13px]">
+    <nav
+      aria-label="Breadcrumb"
+      className={`flex min-w-0 flex-1 items-center gap-1.5 ${className || 'text-[13px]'}`}
+    >
       {currentProjectId && (projects.length > 0 || projectName) ? (
         <>
           <NavigationProjectPicker
             projects={pickerProjects}
             projectId={currentProjectId}
             disabled={branchDisabled}
+            muted={muted}
             onChange={(id) => void switchProject(id)}
             onAddProject={onAddProject}
           />
@@ -202,7 +210,7 @@ export function WorkspaceBreadcrumb({
             current={workspace}
             workspaces={workspaces ?? []}
             disabled={branchDisabled}
-            muted={Boolean(runTitle)}
+            muted={muted || Boolean(runTitle)}
             onRequestNewBranch={onRequestNewBranch}
             unreadWorkspaceIds={unreadWorkspaceIds}
             latestRunIdByWorkspace={latestRunIdByWorkspace}

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -10,7 +10,12 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { Logo } from './__root'
 import { AutomationShortcuts } from '../components/AutomationShortcuts'
-import { NewRunComposer, NewRunModals, NewRunPendingTurn } from '../components/NewRunSurface'
+import {
+  NewRunBreadcrumb,
+  NewRunComposer,
+  NewRunModals,
+  NewRunPendingTurn,
+} from '../components/NewRunSurface'
 import { Button } from '../components/ui'
 import { useNewRunDraft, type NewRunSeed } from '../hooks/useNewRunDraft'
 
@@ -41,11 +46,16 @@ function StartPage() {
               <h1 className="mt-4 text-ui-xl text-foreground">Let's continue some work</h1>
             </div>
 
-            <NewRunComposer
-              draft={draft}
-              placeholder="Ask anything…"
-              className="relative w-full min-w-0"
-            />
+            <div className="space-y-1.5">
+              <NewRunComposer
+                draft={draft}
+                placeholder="Ask anything…"
+                className="relative w-full min-w-0"
+              />
+              <div className="flex min-w-0 px-1">
+                <NewRunBreadcrumb draft={draft} compact />
+              </div>
+            </div>
 
             {noProjects ? (
               <div className="rounded-xl border border-border bg-elevated/40 px-4 py-3.5">


### PR DESCRIPTION
## Summary
- The start page shows the selected project and branch below the composer so you can see where a new chat will land before sending the first message.
- Project and branch pickers on the start page use the same compact, muted styling as the run breadcrumb.

## Test plan
- [ ] Open `/` with at least one project configured and confirm the project and branch appear below the composer
- [ ] Switch project and branch from the start page picker and start a chat; the run opens on the selected workspace
- [ ] Open `/` with no projects and confirm the empty-state prompt still appears without the picker breaking layout

Made with [Cursor](https://cursor.com)