### PR TITLE
fix(web): preserve edits and recover live streams

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,7 +32,7 @@ pnpm typecheck       # tsc --noEmit
 pnpm contract:generate # rebuild every transport from src/contract/operations.ts
 pnpm contract:check    # regenerate, then fail if anything drifted (CI gate)
 pnpm test            # unit tests
-pnpm generate-routes # tsr generate  (see the routeTree gotcha — prefer `pnpm build`)
+pnpm generate-routes # compatibility alias for the Vite build, which regenerates routes
 pnpm ship "feat(x): y" # branch off main, commit, push, open the PR
 pnpm release:plan    # read-only: what would the next release be?
 pnpm release:prepare # write the version + changelog onto release/vX.Y.Z (--dry-run to rehearse)
@@ -390,10 +390,10 @@ one-paragraph import, never a restatement.
   run `pnpm contract:generate`. The generator formats its own output with Biome, so
   `pnpm lint:fix` and the generator cannot disagree.
 - `src/routeTree.gen.ts` is **generated**. Never hand-edit it, and don't resolve conflicts in
-  it by hand — regenerate. Regenerate with **`pnpm build`** (or `pnpm dev`), not
-  `pnpm generate-routes`: the standalone router-cli currently emits a different `Register`
-  block from the Vite plugin, dropping the `config` entry that types the `src/start.ts`
-  instance. The plugin's output is authoritative.
+  it by hand — regenerate with **`pnpm build`** (or `pnpm dev`). The compatibility
+  command `pnpm generate-routes` also runs the Vite build. Use the Vite plugin rather
+  than the standalone router CLI so the `Register` block retains the `config` entry
+  that types the `src/start.ts` instance.
 - Runs, automations, and the rest of app state live in `~/.openrun/openrun.db`
   (`OPENRUN_HOME` overrides the whole directory). Delete that file to reset.
   A leftover `data/openrun.db` in a checkout is moved there on first boot.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,7 +60,7 @@ back, so they are worth knowing up front:
    module** (`lib/runPrereqGate.ts`, `enableGate.ts`, `runNowGate.ts`,
    `projectGate.ts`, `gitActionGate.ts`) — otherwise the UI and the server drift
    and the button lies.
-7. **Never hand-edit `src/routeTree.gen.ts`.** Run `pnpm generate-routes`.
+7. **Never hand-edit `src/routeTree.gen.ts`.** Run `pnpm build` to regenerate it.
 
 ## Conventions
 

--- a/NOTICE
+++ b/NOTICE
@@ -115,7 +115,6 @@ Direct production dependencies:
     @tanstack/react-query                  MIT
     @tanstack/react-router                 MIT
     @tanstack/react-start                  MIT
-    @tanstack/react-devtools               MIT
     @uiw/react-codemirror                  MIT
     better-sqlite3                         MIT
     cron-parser                            MIT

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ no hosted runner, no account. Your repositories never leave your disk.
 
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPL_v3-blue.svg)](./LICENSE)
 [![CI](https://github.com/dennisadriaans/openrun/actions/workflows/ci.yml/badge.svg)](https://github.com/dennisadriaans/openrun/actions/workflows/ci.yml)
-[![Node](https://img.shields.io/badge/node-%3E%3D22.6-informational)](https://nodejs.org)
+[![Node](https://img.shields.io/badge/node-%3E%3D22.12-informational)](https://nodejs.org)
 
 <img src="./public/screenshots/setup-automation.png" alt="Open Run automation setup: project, agent instructions, runtime and triggers." width="900">
 
@@ -53,7 +53,7 @@ Open <http://localhost:3000>.
 
 ### Requirements
 
-- Node 22.6+ and pnpm 10+
+- Node 22.12+ and pnpm 10+
 - git
 - At least one agent CLI logged in: `claude`, `codex`, `grok`, `agy` or `fx`
 - macOS and Linux natively; Windows through WSL2

--- a/changelog.d/web-reliability.md
+++ b/changelog.d/web-reliability.md
@@ -1,0 +1,9 @@
+You no longer lose unsaved file edits when the browser refreshes workspace data
+or when an earlier save finishes. Saving also refreshes the workspace diff.
+
+You no longer need to reload when a live connection stalls before opening, and
+continuous activity no longer postpones list updates indefinitely.
+
+You no longer install unused React devtools and the standalone router CLI. Setup
+now specifies Node 22.12+, route generation uses the same Vite build as CI, and
+development flags work after pnpm's `--` separator.

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "license": "AGPL-3.0-only",
   "packageManager": "pnpm@10.6.5",
   "engines": {
-    "node": ">=22.6.0",
+    "node": ">=22.12.0",
     "pnpm": ">=10"
   },
   "type": "module",
@@ -30,7 +30,7 @@
   "scripts": {
     "dev": "node --experimental-strip-types scripts/dev.ts",
     "dev:mobile": "AGENTOPS_MOBILE=1 vite dev --port 3000",
-    "generate-routes": "tsr generate",
+    "generate-routes": "vite build",
     "build": "vite build",
     "start": "node --experimental-strip-types scripts/start.ts",
     "token:print": "node --experimental-strip-types scripts/token.ts",
@@ -64,10 +64,8 @@
     "@codemirror/view": "^6.43.8",
     "@lezer/highlight": "^1.2.3",
     "@tailwindcss/vite": "^4.1.18",
-    "@tanstack/react-devtools": "^0.10.9",
     "@tanstack/react-query": "^5.66.0",
     "@tanstack/react-router": "^1.170.25",
-    "@tanstack/react-router-devtools": "^1.167.1",
     "@tanstack/react-start": "^1.168.42",
     "@uiw/react-codemirror": "^4.25.11",
     "better-sqlite3": "^13.0.3",
@@ -86,7 +84,6 @@
     "@agentclientprotocol/sdk": "1.3.0",
     "@biomejs/biome": "2.5.8",
     "@tanstack/devtools-vite": "^0.8.3",
-    "@tanstack/router-cli": "^1.167.27",
     "@types/better-sqlite3": "^9.6.0",
     "@types/node": "^26.2.0",
     "@types/node-cron": "^3.0.11",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,18 +57,12 @@ importers:
       '@tailwindcss/vite':
         specifier: ^4.1.18
         version: 4.3.3(vite@8.2.1(@types/node@26.2.0)(jiti@2.7.0))
-      '@tanstack/react-devtools':
-        specifier: ^0.10.9
-        version: 0.10.10(@neodrag/core@3.0.0-next.11)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(csstype@3.2.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(solid-js@1.9.14)
       '@tanstack/react-query':
         specifier: ^5.66.0
         version: 5.101.4(react@19.2.8)
       '@tanstack/react-router':
         specifier: ^1.170.25
         version: 1.170.29(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@tanstack/react-router-devtools':
-        specifier: ^1.167.1
-        version: 1.167.1(@tanstack/react-router@1.170.29(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@tanstack/router-core@1.171.24)(csstype@3.2.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@tanstack/react-start':
         specifier: ^1.168.42
         version: 1.168.46(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(rolldown@1.2.4)(vite@8.2.1(@types/node@26.2.0)(jiti@2.7.0))
@@ -118,9 +112,6 @@ importers:
       '@tanstack/devtools-vite':
         specifier: ^0.8.3
         version: 0.8.3(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)(vite@8.2.1(@types/node@26.2.0)(jiti@2.7.0))
-      '@tanstack/router-cli':
-        specifier: ^1.167.27
-        version: 1.167.30
       '@types/better-sqlite3':
         specifier: ^9.6.0
         version: 9.6.0
@@ -405,15 +396,6 @@ packages:
       '@emnapi/core': ^1.7.1 || ^2.0.0-alpha.4
       '@emnapi/runtime': ^1.7.1 || ^2.0.0-alpha.4
 
-  '@neodrag/core@3.0.0-next.11':
-    resolution: {integrity: sha512-3WQWxyrbxiaK9zS5JU2wJsW2gpoQlZBXVghduBh61JpqaeE0T0cte8R0qYK2RuJo3J2TYQYqxO19CpG/C1i5eg==}
-
-  '@neodrag/solid@3.0.0-next.11':
-    resolution: {integrity: sha512-vCBIn/pimjWMQ6vhTS2/O1XNAwzVtc4eUhdbQ91WykbZWWqQ5NocDXt/1OdYrEkeRzJcpCv8wEz5PnMkgKP81Q==}
-    peerDependencies:
-      '@neodrag/core': 3.0.0-next.11
-      solid-js: ^1.0.0
-
   '@oozcitak/dom@2.0.2':
     resolution: {integrity: sha512-GjpKhkSYC3Mj4+lfwEyI1dqnsKTgwGy48ytZEhm4A/xnH/8z9M3ZVXKr/YGQi3uCLs1AEBS+x5T2JPiueEDW8w==}
     engines: {node: '>=20.0'}
@@ -642,36 +624,6 @@ packages:
   '@rolldown/pluginutils@1.0.1':
     resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
 
-  '@solid-primitives/event-listener@2.4.6':
-    resolution: {integrity: sha512-5I0YJcTVYIWoMmgBSROBZGcz+ymhew/pGTg2dHW74BUjFKsV8Li4bOZYl0YAGP4mHw5o4UBd9/BEesqBci3wxw==}
-    peerDependencies:
-      solid-js: ^1.6.12
-
-  '@solid-primitives/keyboard@1.3.7':
-    resolution: {integrity: sha512-558RPNYnXx4nGh537DSqAn4xMrC8iFipl/5+xzgzWoTNFst4RnUN3BOLmtDjJ0UGGoQXVMALYR3bNOHM0xnt1Q==}
-    peerDependencies:
-      solid-js: ^1.6.12
-
-  '@solid-primitives/resize-observer@2.2.0':
-    resolution: {integrity: sha512-9Fuu/EWBeGj+atGHRJp70HKhdfalmpjwxY8a32NZixdLNmfCJ45AfhLQNr6uOzETbbiMx4iCKlTrJ8KZCHC2Ww==}
-    peerDependencies:
-      solid-js: ^1.6.12
-
-  '@solid-primitives/rootless@1.5.4':
-    resolution: {integrity: sha512-TOIZa1VUfVJ+9nkCcRajw3U4t9vBOP1HxX1WHNTbXq32mXwlqTvUnC4CRIilohcryBkT9u2ZkhUDSHRTaGp55g==}
-    peerDependencies:
-      solid-js: ^1.6.12
-
-  '@solid-primitives/static-store@0.1.4':
-    resolution: {integrity: sha512-LgtVaVBtB7EbmS4+M0b8xY5Iq6pUWXBsIC4VgtrFKDGDdyCaDt88sHk0fUlx1Enxm/XZnZyLXJABRoa39RjJqA==}
-    peerDependencies:
-      solid-js: ^1.6.12
-
-  '@solid-primitives/utils@6.4.1':
-    resolution: {integrity: sha512-ISSB5QX1qP2ynrheIpYwc4oKR5Ny4siNuUyf1qZniy+Il+p/PtDB0QK1Dnle8noiHpwRD3gpPdubOC3qI/Zamg==}
-    peerDependencies:
-      solid-js: ^1.6.12
-
   '@tailwindcss/node@4.3.3':
     resolution: {integrity: sha512-/T8IKEsf9VTU6tLjgC7+sv2mOPtQxzE2jMw7u4Tt40Tx+QSZxpzh95/H6cMKoja9XuW7iMdLJYBB0o9G1CaAgg==}
 
@@ -779,25 +731,12 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
-  '@tanstack/devtools-ui@0.7.0':
-    resolution: {integrity: sha512-px/a+JgRSVHDj/hID1cwfsIi+ly5l7t3Yw7fLw4G556HXCNgDri36fupt9h7oBeEKntpsx3ep/XtZn51rrCv2g==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      solid-js: '>=1.9.7'
-
   '@tanstack/devtools-vite@0.8.3':
     resolution: {integrity: sha512-MqqE4/rdQUG55Y8Zux1Jj1I2wIBHdqYgjAJzP1grMUtFqSZ2XIDB7BHEV9UW/vrbhK7ocl4yFgVaJWROv0zeDA==}
     engines: {node: '>=18'}
     hasBin: true
     peerDependencies:
       vite: ^6.0.0 || ^7.0.0 || ^8.0.0
-
-  '@tanstack/devtools@0.14.0':
-    resolution: {integrity: sha512-tN0SEi1BVaJYtkZbgYpvLsInjwNRAZkR3r6slSvz9Jm+bfkhcdjuOSrZp0cAwOGwdnauHZ1mYgtfe2AfC/V1NQ==}
-    engines: {node: '>=18'}
-    hasBin: true
-    peerDependencies:
-      solid-js: '>=1.9.7'
 
   '@tanstack/history@1.162.1':
     resolution: {integrity: sha512-DR9t6lfLVdrjgCwpglrR9DR7Ok8/HlXjcOE+goWXF3zyuLUO/ug7vMbSFxTqrQTtbRghJfyhmIZ0S6LhPIy44w==}
@@ -806,31 +745,10 @@ packages:
   '@tanstack/query-core@5.101.4':
     resolution: {integrity: sha512-gNwcvOJcRbLWPOLG/2OBm+zM+Yv+MKsXKEOWC57USuZDEsI71hEErQsiEGx5wX9rzWWkfwM0fVSPoiIFSsxfiw==}
 
-  '@tanstack/react-devtools@0.10.10':
-    resolution: {integrity: sha512-hYH34MSVbajs1pUc22ftSapyKQp2gOh0w34a7ouYOdIcbXD6YPckSR2YpAWGq1rrs6N0l/rvV6LM/G1pgN5ARg==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      '@types/react': '>=16.8'
-      '@types/react-dom': '>=16.8'
-      react: '>=16.8'
-      react-dom: '>=16.8'
-
   '@tanstack/react-query@5.101.4':
     resolution: {integrity: sha512-yRg2pfOCxIs4ZJW3XYYHU/WgtD04FHSnfHlpRT7h7pR77hwkdRG4wxbKe4aq6P0RvXUTBSQpQeadS1SUYUe+KA==}
     peerDependencies:
       react: ^18 || ^19
-
-  '@tanstack/react-router-devtools@1.167.1':
-    resolution: {integrity: sha512-pjfGrmjj4d7naEPM7oshqFfwBoxDPNo/UxltlHH5ePbHsJ+plBhd+JaAewm1ueYOjZ0js9hckjWWDYXpCrSfKw==}
-    engines: {node: '>=20.19'}
-    peerDependencies:
-      '@tanstack/react-router': ^1.170.19
-      '@tanstack/router-core': ^1.171.16
-      react: '>=18.0.0 || >=19.0.0'
-      react-dom: '>=18.0.0 || >=19.0.0'
-    peerDependenciesMeta:
-      '@tanstack/router-core':
-        optional: true
 
   '@tanstack/react-router@1.170.29':
     resolution: {integrity: sha512-xQwakR0ReaUGu3xeXEl2CqzlIXk4i9vxaf/zqdzoELMY0mDZgMOr+xobiA5cQdn8cnovqZgqqUxcwXhsruC+NA==}
@@ -893,24 +811,9 @@ packages:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
-  '@tanstack/router-cli@1.167.30':
-    resolution: {integrity: sha512-qds8Fl+VY5KU1xlTUHRT12hXSujr8TW3TqE1hwotDjh3SGMQ/uEO6gF57FiEZNIg3L896f3XLZ30JgF8C7WbGw==}
-    engines: {node: '>=20.19'}
-    hasBin: true
-
   '@tanstack/router-core@1.171.24':
     resolution: {integrity: sha512-+j+8NmV4QOS+ILNLdXFlLTdKPPbBQIy6mXDZ0QWEKYZ0xQOdlnOCXVHPflyGanD2SWSxjqGkw8CsW0CXXP7fLg==}
     engines: {node: '>=20.19'}
-
-  '@tanstack/router-devtools-core@1.168.1':
-    resolution: {integrity: sha512-qr4voa4cpSMwQvS3867xkU3AB3MtJbTuovKIy+btjJ/Faju6er9w0nDylmD+005Mk/3YKw9/iueZJl2JAB7JOA==}
-    engines: {node: '>=20.19'}
-    peerDependencies:
-      '@tanstack/router-core': ^1.171.16
-      csstype: ^3.0.10
-    peerDependenciesMeta:
-      csstype:
-        optional: true
 
   '@tanstack/router-generator@1.167.30':
     resolution: {integrity: sha512-Tf9TJfdpP0yL3k1D1ke6hR1dvPCgKShTik3HcBRDeTK5eNrp9/X0Q0YApN8thE6pVcXL6a78O3ZE7XN7s7KwNw==}
@@ -1249,14 +1152,6 @@ packages:
   cliui@6.0.0:
     resolution: {integrity: sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==}
 
-  cliui@8.0.1:
-    resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
-    engines: {node: '>=12'}
-
-  clsx@2.1.1:
-    resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
-    engines: {node: '>=6'}
-
   codemirror@6.0.2:
     resolution: {integrity: sha512-VhydHotNW5w1UGK0Qj96BwSk/Zqbp9WbnyK2W/eVMv4QyF41INRGpjUhFJY7/uDNuudSc33a/PKr4iDqRduvHw==}
 
@@ -1286,9 +1181,6 @@ packages:
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
-
-  dayjs@1.11.22:
-    resolution: {integrity: sha512-1YRnxzt/AabP3GHxnaB9/b+ZScCKu5TeF+co+BWG+lnWVIwEcTFc1FVE0WLNmNO3sA6GGXL40i5qkHfbLzpwrg==}
 
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
@@ -1379,11 +1271,6 @@ packages:
   get-caller-file@2.0.5:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
-
-  goober@2.1.19:
-    resolution: {integrity: sha512-U7veizMqxyKlM58+Z5j2ngJBH/r9siDmxpvNxSw0PylF6WQvrASJEZrxh1hidRBJc2jqoBVSyOban5u8m+6Rxg==}
-    peerDependencies:
-      csstype: ^3.0.10
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
@@ -1879,21 +1766,11 @@ packages:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
 
-  seroval-plugins@1.5.6:
-    resolution: {integrity: sha512-HXuLAX2pu/UByPpaeo/TaMfvMIi+1QqIoPJYCcAtU8QkVNwgR6MPlGuCQTErV1JwraaMbYaWVIBX7mppzGLATQ==}
-    engines: {node: '>=10'}
-    peerDependencies:
-      seroval: ^1.0
-
   seroval-plugins@1.6.2:
     resolution: {integrity: sha512-TfxuUjlbBESzUOWdTkTKqvSmav0ABym+itetDXLK6mDz8SmrpdI30aF8RTXE8Bvq+tH/1yIDkvy3W0lfQb1ipQ==}
     engines: {node: '>=10'}
     peerDependencies:
       seroval: ^1.0
-
-  seroval@1.5.6:
-    resolution: {integrity: sha512-rVQVWjjSvlINzaQPZH5JFqsqEsIWdTxY3iJZCnTL/5gQbXIRooVZKI60tVCkOVfzcRPejboxO2t0P89dg5mQaA==}
-    engines: {node: '>=10'}
 
   seroval@1.6.2:
     resolution: {integrity: sha512-mPT+SD2TrlB6wvte1KkYOYUkubaTbd6pZ/6Kk3C9nxzrHmCZyhxOO7XGAeL7f+yLKZglzGtM9odUVvg/EhO+vQ==}
@@ -1909,9 +1786,6 @@ packages:
   simple-icons@16.28.0:
     resolution: {integrity: sha512-sQPR5AtK/ijRjou7zw7mlLp08oB6FH7i0lOy5XJ2zp9mJs/yejgiOn7KvQoe2q4YJIx6VmgUSW5AOefebPt5kg==}
     engines: {node: '>=0.12.18'}
-
-  solid-js@1.9.14:
-    resolution: {integrity: sha512-sAEXC0Kk0S1EDg+8ysEWJDbYhA3RRoEjwuySUGlKIemeo0I5YZfOyumNjNs9Sv3y2nmhD+0rW66ag2HsMuQiGQ==}
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -2112,10 +1986,6 @@ packages:
     resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
     engines: {node: '>=8'}
 
-  wrap-ansi@7.0.0:
-    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
-    engines: {node: '>=10'}
-
   ws@8.21.3:
     resolution: {integrity: sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==}
     engines: {node: '>=10.0.0'}
@@ -2135,10 +2005,6 @@ packages:
   y18n@4.0.3:
     resolution: {integrity: sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==}
 
-  y18n@5.0.8:
-    resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
-    engines: {node: '>=10'}
-
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
 
@@ -2146,17 +2012,9 @@ packages:
     resolution: {integrity: sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==}
     engines: {node: '>=6'}
 
-  yargs-parser@21.1.1:
-    resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
-    engines: {node: '>=12'}
-
   yargs@15.4.1:
     resolution: {integrity: sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==}
     engines: {node: '>=8'}
-
-  yargs@17.7.3:
-    resolution: {integrity: sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==}
-    engines: {node: '>=12'}
 
   zod@4.4.3:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
@@ -2552,13 +2410,6 @@ snapshots:
       '@tybys/wasm-util': 0.10.3
     optional: true
 
-  '@neodrag/core@3.0.0-next.11': {}
-
-  '@neodrag/solid@3.0.0-next.11(@neodrag/core@3.0.0-next.11)(solid-js@1.9.14)':
-    dependencies:
-      '@neodrag/core': 3.0.0-next.11
-      solid-js: 1.9.14
-
   '@oozcitak/dom@2.0.2':
     dependencies:
       '@oozcitak/infra': 2.0.2
@@ -2689,40 +2540,6 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.1': {}
 
-  '@solid-primitives/event-listener@2.4.6(solid-js@1.9.14)':
-    dependencies:
-      '@solid-primitives/utils': 6.4.1(solid-js@1.9.14)
-      solid-js: 1.9.14
-
-  '@solid-primitives/keyboard@1.3.7(solid-js@1.9.14)':
-    dependencies:
-      '@solid-primitives/event-listener': 2.4.6(solid-js@1.9.14)
-      '@solid-primitives/rootless': 1.5.4(solid-js@1.9.14)
-      '@solid-primitives/utils': 6.4.1(solid-js@1.9.14)
-      solid-js: 1.9.14
-
-  '@solid-primitives/resize-observer@2.2.0(solid-js@1.9.14)':
-    dependencies:
-      '@solid-primitives/event-listener': 2.4.6(solid-js@1.9.14)
-      '@solid-primitives/rootless': 1.5.4(solid-js@1.9.14)
-      '@solid-primitives/static-store': 0.1.4(solid-js@1.9.14)
-      '@solid-primitives/utils': 6.4.1(solid-js@1.9.14)
-      solid-js: 1.9.14
-
-  '@solid-primitives/rootless@1.5.4(solid-js@1.9.14)':
-    dependencies:
-      '@solid-primitives/utils': 6.4.1(solid-js@1.9.14)
-      solid-js: 1.9.14
-
-  '@solid-primitives/static-store@0.1.4(solid-js@1.9.14)':
-    dependencies:
-      '@solid-primitives/utils': 6.4.1(solid-js@1.9.14)
-      solid-js: 1.9.14
-
-  '@solid-primitives/utils@6.4.1(solid-js@1.9.14)':
-    dependencies:
-      solid-js: 1.9.14
-
   '@tailwindcss/node@4.3.3':
     dependencies:
       '@jridgewell/remapping': 2.3.5
@@ -2819,15 +2636,6 @@ snapshots:
 
   '@tanstack/devtools-event-client@0.5.0': {}
 
-  '@tanstack/devtools-ui@0.7.0(csstype@3.2.3)(solid-js@1.9.14)':
-    dependencies:
-      clsx: 2.1.1
-      dayjs: 1.11.22
-      goober: 2.1.19(csstype@3.2.3)
-      solid-js: 1.9.14
-    transitivePeerDependencies:
-      - csstype
-
   '@tanstack/devtools-vite@0.8.3(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)(vite@8.2.1(@types/node@26.2.0)(jiti@2.7.0))':
     dependencies:
       '@tanstack/devtools-bundler-core': 0.1.1(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)
@@ -2841,57 +2649,14 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@tanstack/devtools@0.14.0(@neodrag/core@3.0.0-next.11)(csstype@3.2.3)(solid-js@1.9.14)':
-    dependencies:
-      '@neodrag/solid': 3.0.0-next.11(@neodrag/core@3.0.0-next.11)(solid-js@1.9.14)
-      '@solid-primitives/event-listener': 2.4.6(solid-js@1.9.14)
-      '@solid-primitives/keyboard': 1.3.7(solid-js@1.9.14)
-      '@solid-primitives/resize-observer': 2.2.0(solid-js@1.9.14)
-      '@tanstack/devtools-client': 0.0.8
-      '@tanstack/devtools-event-bus': 0.4.2
-      '@tanstack/devtools-ui': 0.7.0(csstype@3.2.3)(solid-js@1.9.14)
-      clsx: 2.1.1
-      goober: 2.1.19(csstype@3.2.3)
-      solid-js: 1.9.14
-    transitivePeerDependencies:
-      - '@neodrag/core'
-      - bufferutil
-      - csstype
-      - utf-8-validate
-
   '@tanstack/history@1.162.1': {}
 
   '@tanstack/query-core@5.101.4': {}
-
-  '@tanstack/react-devtools@0.10.10(@neodrag/core@3.0.0-next.11)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(csstype@3.2.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(solid-js@1.9.14)':
-    dependencies:
-      '@tanstack/devtools': 0.14.0(@neodrag/core@3.0.0-next.11)(csstype@3.2.3)(solid-js@1.9.14)
-      '@types/react': 19.2.18
-      '@types/react-dom': 19.2.4(@types/react@19.2.18)
-      react: 19.2.8
-      react-dom: 19.2.8(react@19.2.8)
-    transitivePeerDependencies:
-      - '@neodrag/core'
-      - bufferutil
-      - csstype
-      - solid-js
-      - utf-8-validate
 
   '@tanstack/react-query@5.101.4(react@19.2.8)':
     dependencies:
       '@tanstack/query-core': 5.101.4
       react: 19.2.8
-
-  '@tanstack/react-router-devtools@1.167.1(@tanstack/react-router@1.170.29(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@tanstack/router-core@1.171.24)(csstype@3.2.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
-    dependencies:
-      '@tanstack/react-router': 1.170.29(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@tanstack/router-devtools-core': 1.168.1(@tanstack/router-core@1.171.24)(csstype@3.2.3)
-      react: 19.2.8
-      react-dom: 19.2.8(react@19.2.8)
-    optionalDependencies:
-      '@tanstack/router-core': 1.171.24
-    transitivePeerDependencies:
-      - csstype
 
   '@tanstack/react-router@1.170.29(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
@@ -2982,28 +2747,12 @@ snapshots:
       react-dom: 19.2.8(react@19.2.8)
       use-sync-external-store: 1.6.0(react@19.2.8)
 
-  '@tanstack/router-cli@1.167.30':
-    dependencies:
-      '@tanstack/router-generator': 1.167.30
-      chokidar: 5.0.0
-      yargs: 17.7.3
-    transitivePeerDependencies:
-      - supports-color
-
   '@tanstack/router-core@1.171.24':
     dependencies:
       '@tanstack/history': 1.162.1
       cookie-es: 3.1.1
       seroval: 1.6.2
       seroval-plugins: 1.6.2(seroval@1.6.2)
-
-  '@tanstack/router-devtools-core@1.168.1(@tanstack/router-core@1.171.24)(csstype@3.2.3)':
-    dependencies:
-      '@tanstack/router-core': 1.171.24
-      clsx: 2.1.1
-      goober: 2.1.19(csstype@3.2.3)
-    optionalDependencies:
-      csstype: 3.2.3
 
   '@tanstack/router-generator@1.167.30':
     dependencies:
@@ -3328,14 +3077,6 @@ snapshots:
       strip-ansi: 6.0.1
       wrap-ansi: 6.2.0
 
-  cliui@8.0.1:
-    dependencies:
-      string-width: 4.2.3
-      strip-ansi: 6.0.1
-      wrap-ansi: 7.0.0
-
-  clsx@2.1.1: {}
-
   codemirror@6.0.2:
     dependencies:
       '@codemirror/autocomplete': 6.20.3
@@ -3365,8 +3106,6 @@ snapshots:
       luxon: 3.7.2
 
   csstype@3.2.3: {}
-
-  dayjs@1.11.22: {}
 
   debug@4.4.3:
     dependencies:
@@ -3426,10 +3165,6 @@ snapshots:
   gensync@1.0.0-beta.2: {}
 
   get-caller-file@2.0.5: {}
-
-  goober@2.1.19(csstype@3.2.3):
-    dependencies:
-      csstype: 3.2.3
 
   graceful-fs@4.2.11: {}
 
@@ -4139,15 +3874,9 @@ snapshots:
 
   semver@6.3.1: {}
 
-  seroval-plugins@1.5.6(seroval@1.5.6):
-    dependencies:
-      seroval: 1.5.6
-
   seroval-plugins@1.6.2(seroval@1.6.2):
     dependencies:
       seroval: 1.6.2
-
-  seroval@1.5.6: {}
 
   seroval@1.6.2: {}
 
@@ -4156,12 +3885,6 @@ snapshots:
   shell-quote@1.10.0: {}
 
   simple-icons@16.28.0: {}
-
-  solid-js@1.9.14:
-    dependencies:
-      csstype: 3.2.3
-      seroval: 1.5.6
-      seroval-plugins: 1.5.6(seroval@1.5.6)
 
   source-map-js@1.2.1: {}
 
@@ -4329,12 +4052,6 @@ snapshots:
       string-width: 4.2.3
       strip-ansi: 6.0.1
 
-  wrap-ansi@7.0.0:
-    dependencies:
-      ansi-styles: 4.3.0
-      string-width: 4.2.3
-      strip-ansi: 6.0.1
-
   ws@8.21.3: {}
 
   xmlbuilder2@4.0.3:
@@ -4346,16 +4063,12 @@ snapshots:
 
   y18n@4.0.3: {}
 
-  y18n@5.0.8: {}
-
   yallist@3.1.1: {}
 
   yargs-parser@18.1.3:
     dependencies:
       camelcase: 5.3.1
       decamelize: 1.2.0
-
-  yargs-parser@21.1.1: {}
 
   yargs@15.4.1:
     dependencies:
@@ -4370,16 +4083,6 @@ snapshots:
       which-module: 2.0.1
       y18n: 4.0.3
       yargs-parser: 18.1.3
-
-  yargs@17.7.3:
-    dependencies:
-      cliui: 8.0.1
-      escalade: 3.2.0
-      get-caller-file: 2.0.5
-      require-directory: 2.1.1
-      string-width: 4.2.3
-      y18n: 5.0.8
-      yargs-parser: 21.1.1
 
   zod@4.4.3: {}
 

--- a/scripts/dev.ts
+++ b/scripts/dev.ts
@@ -6,7 +6,8 @@ import { spawn } from 'node:child_process'
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
-const argv = process.argv.slice(2)
+const forwarded = process.argv.slice(2)
+const argv = forwarded[0] === '--' ? forwarded.slice(1) : forwarded
 const demo = argv.includes('--demo')
 const viteArgs = argv.filter((arg) => arg !== '--demo')
 if (demo) process.env.OPENRUN_DEMO = '1'

--- a/src/components/workspace/FileEditor.tsx
+++ b/src/components/workspace/FileEditor.tsx
@@ -5,8 +5,7 @@
  * merge view of the on-disk file against the version last loaded from the
  * server, so unsaved edits are visible before committing to them.
  */
-import { useQuery, useQueryClient } from '@tanstack/react-query'
-import { useMutation } from '@tanstack/react-query'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import CodeMirror from '@uiw/react-codemirror'
 import { EditorView } from '@codemirror/view'
 import { MergeView } from '@codemirror/merge'
@@ -71,7 +70,8 @@ export function FileEditor({
 }) {
   const qc = useQueryClient()
   const [mode, setMode] = useState<Mode>('edit')
-  const [draft, setDraft] = useState('')
+  // Until the user edits, display the query directly. Refetches never replace a draft.
+  const [draft, setDraft] = useState<string | null>(null)
   const [saveError, setSaveError] = useState<string | null>(null)
 
   const file = useQuery({
@@ -80,21 +80,23 @@ export function FileEditor({
     staleTime: 0,
   })
 
-  // Reset the buffer whenever a different file (or fresh content) arrives.
   const saved = file.data?.content ?? ''
-  useEffect(() => {
-    setDraft(saved)
-    setSaveError(null)
-    setMode('edit')
-  }, [saved, path])
+  const content = draft ?? saved
 
   const save = useMutation({
     mutationFn: (content: string) => fns.writeWorkspaceFile({ data: { runId, path, content } }),
-    onSuccess: () => {
+    onSuccess: async (result, submitted) => {
+      // Discard reads started before the write, then cache the confirmed contents.
+      await qc.cancelQueries({ queryKey: ['workspace-file', runId, path] })
+      qc.setQueryData<typeof file.data>(['workspace-file', runId, path], (previous) =>
+        previous ? { ...previous, content: submitted, size: result.size } : previous,
+      )
+      // Typing can continue while the write is in flight.
+      setDraft((current) => (current === submitted ? null : current))
       setSaveError(null)
-      // Refresh the file and any diff/status views that depend on it.
-      qc.invalidateQueries({ queryKey: ['workspace-file', runId, path] })
-      qc.invalidateQueries({ queryKey: ['conversation', runId] })
+      void qc.invalidateQueries({ queryKey: ['runWorkspace', runId] })
+      void qc.invalidateQueries({ queryKey: ['fileDiff', runId, path] })
+      void qc.invalidateQueries({ queryKey: ['conversation', runId] })
     },
     onError: (err: unknown) => {
       setSaveError(err instanceof Error ? err.message : String(err))
@@ -102,19 +104,19 @@ export function FileEditor({
   })
 
   const readOnly = file.data?.readOnly ?? false
-  const dirty = !readOnly && draft !== saved
+  const dirty = !readOnly && content !== saved
 
   // Cmd/Ctrl+S saves without leaving the editor.
   useEffect(() => {
     const onKeyDown = (e: KeyboardEvent) => {
       if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 's') {
         e.preventDefault()
-        if (dirty && !save.isPending) save.mutate(draft)
+        if (dirty && !save.isPending) save.mutate(content)
       }
     }
     window.addEventListener('keydown', onKeyDown)
     return () => window.removeEventListener('keydown', onKeyDown)
-  }, [dirty, draft, save])
+  }, [dirty, content, save])
 
   const extensions = useMemo(
     () => [workspaceSyntaxHighlighting, EditorView.lineWrapping, ...languageForPath(path)],
@@ -162,7 +164,7 @@ export function FileEditor({
           <button
             type="button"
             disabled={!dirty || save.isPending}
-            onClick={() => save.mutate(draft)}
+            onClick={() => save.mutate(content)}
             title="Save (Ctrl/Cmd+S)"
             className="flex shrink-0 items-center gap-1 rounded-md border border-border bg-[var(--bg-luminous-quaternary)] px-2 py-1 text-[11px] text-foreground transition-colors hover:bg-[var(--bg-luminous-tertiary)] disabled:cursor-not-allowed disabled:opacity-40"
           >
@@ -209,10 +211,10 @@ export function FileEditor({
             </p>
           </div>
         ) : mode === 'diff' ? (
-          <DiffView original={saved} modified={draft} path={path} />
+          <DiffView original={saved} modified={content} path={path} />
         ) : (
           <CodeMirror
-            value={draft}
+            value={content}
             onChange={setDraft}
             extensions={extensions}
             theme={workspaceEditorTheme}

--- a/src/components/workspace/PanelLayoutControls.tsx
+++ b/src/components/workspace/PanelLayoutControls.tsx
@@ -1,4 +1,4 @@
-import { ChevronDown, Maximize2, Minimize2, PanelBottom, PanelRight } from 'lucide-react'
+import { ChevronDown, Maximize2, Minimize2, PanelRight } from 'lucide-react'
 import type { ComponentType, ReactNode } from 'react'
 
 /** Bordered chip used in the workspace top bars (git menu, panel tabs, etc.). */
@@ -69,23 +69,6 @@ function ToggleButton({
     >
       <Icon className="size-3.5" />
     </button>
-  )
-}
-
-export function TerminalToggleControl({
-  terminalOpen,
-  onToggle,
-}: {
-  terminalOpen: boolean
-  onToggle: () => void
-}) {
-  return (
-    <ToggleButton
-      icon={PanelBottom}
-      label="Toggle terminal"
-      active={terminalOpen}
-      onToggle={onToggle}
-    />
   )
 }
 

--- a/src/components/workspace/RightPanel.tsx
+++ b/src/components/workspace/RightPanel.tsx
@@ -34,8 +34,6 @@ export function RightPanel({
   reviewPath,
   undoDisabled = false,
   undoDisabledReason,
-  terminalOpen: _terminalOpen,
-  onToggleTerminal: _onToggleTerminal,
   onToggleRightPanel,
   maximized = false,
   onToggleMaximized,
@@ -55,8 +53,6 @@ export function RightPanel({
   reviewPath: string | null
   undoDisabled?: boolean
   undoDisabledReason?: string
-  terminalOpen: boolean
-  onToggleTerminal: () => void
   onToggleRightPanel: () => void
   /** True when the panel has taken over the full workspace width. */
   maximized?: boolean
@@ -92,7 +88,6 @@ export function RightPanel({
   // reachable while the panel is maximized and the chat column is unmounted.
   const layoutControls = (
     <div className="flex shrink-0 items-center gap-0.5">
-      {/* <TerminalToggleControl terminalOpen={terminalOpen} onToggle={onToggleTerminal} /> */}
       <RightPanelMaximizeControl maximized={maximized} onToggle={onToggleMaximized} />
       <RightPanelToggleControl rightPanelOpen onToggle={onToggleRightPanel} />
     </div>
@@ -172,7 +167,12 @@ export function RightPanel({
               </div>
             }
           >
-            <FileEditor runId={runId} path={editingPath} onClose={() => setEditingPath(null)} />
+            <FileEditor
+              key={JSON.stringify([runId, editingPath])}
+              runId={runId}
+              path={editingPath}
+              onClose={() => setEditingPath(null)}
+            />
           </Suspense>
         </div>
       </div>

--- a/src/lib/activityLive.test.ts
+++ b/src/lib/activityLive.test.ts
@@ -5,6 +5,7 @@ import {
   activityLiveInvalidateKeys,
   activityLiveStreamPath,
   needsActivityLiveStream,
+  createActivityBatch,
 } from './activityLive.ts'
 
 describe('activityLiveInvalidateKeys', () => {
@@ -90,5 +91,32 @@ describe('needsActivityLiveStream', () => {
   it('uses only the run-scoped stream on a run detail', () => {
     assert.equal(needsActivityLiveStream('/runs/run_123'), false)
     assert.equal(needsActivityLiveStream('/runs/run_123/'), false)
+  })
+})
+
+describe('activity batching', () => {
+  it('refreshes within 100ms even when events keep arriving', (t) => {
+    t.mock.timers.enable({ apis: ['setTimeout'] })
+    const invalidated: (readonly string[])[] = []
+    const batch = createActivityBatch((key) => invalidated.push(key))
+    t.after(() => batch.close())
+    for (let i = 0; i < 5; i++) {
+      batch.bump([['runs'], ['dashboard']])
+      t.mock.timers.tick(20)
+    }
+    assert.deepEqual(invalidated, [['runs'], ['dashboard']])
+    batch.bump([['runs'], ['task', 'task-1']])
+    t.mock.timers.tick(100)
+    assert.deepEqual(invalidated, [['runs'], ['dashboard'], ['runs'], ['task', 'task-1']])
+  })
+
+  it('does not invalidate after unmount', (t) => {
+    t.mock.timers.enable({ apis: ['setTimeout'] })
+    const invalidated: (readonly string[])[] = []
+    const batch = createActivityBatch((key) => invalidated.push(key))
+    batch.bump([['runs']])
+    batch.close()
+    t.mock.timers.tick(100)
+    assert.deepEqual(invalidated, [])
   })
 })

--- a/src/lib/activityLive.ts
+++ b/src/lib/activityLive.ts
@@ -54,6 +54,30 @@ export function needsActivityLiveStream(pathname: string): boolean {
   return match?.[1] === undefined || match[1] === 'new'
 }
 
+/** Coalesce bursts without postponing refreshes indefinitely under sustained activity. */
+export function createActivityBatch(invalidate: (key: readonly string[]) => void) {
+  const pending = new Map<string, readonly string[]>()
+  let timer: ReturnType<typeof setTimeout> | null = null
+
+  return {
+    bump(keys: readonly (readonly string[])[]) {
+      for (const key of keys) pending.set(JSON.stringify(key), key)
+      if (timer !== null || pending.size === 0) return
+      timer = setTimeout(() => {
+        timer = null
+        const batch = [...pending.values()]
+        pending.clear()
+        for (const key of batch) invalidate(key)
+      }, 100)
+    },
+    close() {
+      if (timer !== null) clearTimeout(timer)
+      timer = null
+      pending.clear()
+    },
+  }
+}
+
 /** Queue depth has its own event; approval frames target one conversation. */
 export const ACTIVITY_LIVE_RESUME_KEYS = [['runs'], ['dashboard'], ['tasks']] as const
 

--- a/src/lib/liveStream.test.ts
+++ b/src/lib/liveStream.test.ts
@@ -1,8 +1,16 @@
 import assert from 'node:assert/strict'
-import { test } from 'node:test'
+import { afterEach, beforeEach, describe, it, mock, test } from 'node:test'
 import { SERVER_PING_MS as activityPing } from '../server/activityLive.ts'
 import { SERVER_PING_MS as runPing } from '../server/runLive.ts'
-import { isStale, nextReconnectDelay, SERVER_PING_MS, STALE_AFTER_MS } from './liveStream.ts'
+import {
+  isStale,
+  liveStreamsSnapshot,
+  nextReconnectDelay,
+  openLiveStream,
+  SERVER_PING_MS,
+  STALE_AFTER_MS,
+} from './liveStream.ts'
+import type { LiveStreamHandle } from './liveStream.ts'
 
 test('the watchdog window is derived from the shared ping period', () => {
   assert.equal(STALE_AFTER_MS, SERVER_PING_MS * 3 - 5_000)
@@ -28,4 +36,103 @@ test('nextReconnectDelay stays inside ±25% jitter of the exponential base', () 
     assert.ok(delay >= Math.round(base * 0.75), `attempt ${attempt}: ${delay} < 0.75*${base}`)
     assert.ok(delay <= Math.round(base * 1.25), `attempt ${attempt}: ${delay} > 1.25*${base}`)
   }
+})
+
+class FakeEventSource {
+  static sockets: FakeEventSource[] = []
+  onopen: (() => void) | null = null
+  onmessage: ((event: { data: string }) => void) | null = null
+  onerror: (() => void) | null = null
+  closed = false
+
+  constructor(_path: string) {
+    FakeEventSource.sockets.push(this)
+  }
+
+  close() {
+    this.closed = true
+  }
+}
+
+describe('live stream recovery', () => {
+  let handle: LiveStreamHandle
+  let original: PropertyDescriptor | undefined
+  let health: boolean[]
+  let resumes: number
+
+  beforeEach(() => {
+    mock.timers.enable({ apis: ['Date', 'setInterval', 'setTimeout'], now: 1_000 })
+    original = Object.getOwnPropertyDescriptor(globalThis, 'EventSource')
+    Object.defineProperty(globalThis, 'EventSource', {
+      configurable: true,
+      value: FakeEventSource,
+    })
+    FakeEventSource.sockets = []
+    health = []
+    resumes = 0
+    handle = openLiveStream({
+      id: 'test',
+      label: 'Test stream',
+      path: '/stream',
+      onHealthyChange: (value) => health.push(value),
+      onMessage: () => false,
+      onResume: () => resumes++,
+    })
+  })
+
+  afterEach(() => {
+    handle.close()
+    if (original) Object.defineProperty(globalThis, 'EventSource', original)
+    else Reflect.deleteProperty(globalThis, 'EventSource')
+    mock.timers.reset()
+  })
+
+  it('retries a connection that never opens or reports an error', () => {
+    const first = FakeEventSource.sockets[0]!
+    mock.timers.tick(STALE_AFTER_MS + 5_000)
+    assert.equal(first.closed, true)
+    mock.timers.tick(2_000)
+    assert.equal(FakeEventSource.sockets.length, 2)
+    assert.equal(liveStreamsSnapshot()[0]!.healthy, false)
+  })
+
+  it('also times out a stalled reconnect without reusing the old heartbeat', () => {
+    FakeEventSource.sockets[0]!.onopen!()
+    mock.timers.tick(20_000)
+    handle.reconnect()
+    const second = FakeEventSource.sockets[1]!
+    mock.timers.tick(STALE_AFTER_MS)
+    assert.equal(second.closed, false)
+    mock.timers.tick(5_000)
+    assert.equal(second.closed, true)
+    mock.timers.tick(2_000)
+    FakeEventSource.sockets.at(-1)!.onopen!()
+    assert.equal(resumes, 1)
+    assert.deepEqual(health, [true, false, true])
+  })
+
+  it('keeps a stream alive while heartbeats arrive and recovers after silence', () => {
+    const first = FakeEventSource.sockets[0]!
+    first.onopen!()
+    for (let i = 0; i < 5; i++) {
+      mock.timers.tick(15_000)
+      first.onmessage!({ data: '{"type":"ping"}' })
+    }
+    assert.equal(first.closed, false)
+    mock.timers.tick(STALE_AFTER_MS + 5_000)
+    assert.equal(first.closed, true)
+    assert.equal(health.at(-1), false)
+  })
+
+  it('cancels pending retries and ignores late socket events after closing', () => {
+    const first = FakeEventSource.sockets[0]!
+    const lateOpen = first.onopen!
+    first.onerror!()
+    handle.close()
+    lateOpen()
+    mock.timers.tick(60_000)
+    assert.equal(FakeEventSource.sockets.length, 1)
+    assert.deepEqual(liveStreamsSnapshot(), [])
+    assert.equal(health.includes(true), false)
+  })
 })

--- a/src/lib/liveStream.ts
+++ b/src/lib/liveStream.ts
@@ -146,6 +146,7 @@ export function openLiveStream(opts: LiveStreamOptions): LiveStreamHandle {
 
   let closed = false
   let es: EventSource | null = null
+  let connectingAt: number | null = null
   let reconnectTimer: ReturnType<typeof setTimeout> | null = null
   let watchdogTimer: ReturnType<typeof setInterval> | null = null
   let hasBeenOpen = false
@@ -171,6 +172,7 @@ export function openLiveStream(opts: LiveStreamOptions): LiveStreamHandle {
     es.onerror = null
     es.close()
     es = null
+    connectingAt = null
   }
 
   const scheduleReconnect = () => {
@@ -194,7 +196,12 @@ export function openLiveStream(opts: LiveStreamOptions): LiveStreamHandle {
   const connect = () => {
     if (closed) return
     teardownSocket()
-    patch({ phase: hasBeenOpen ? 'reconnecting' : 'connecting' })
+    connectingAt = Date.now()
+    patch({
+      phase: hasBeenOpen ? 'reconnecting' : 'connecting',
+      openedAt: null,
+      lastFrameAt: null,
+    })
 
     let socket: EventSource
     try {
@@ -252,6 +259,10 @@ export function openLiveStream(opts: LiveStreamOptions): LiveStreamHandle {
     if (es && snapshot.phase === 'open' && isStale(snapshot.lastFrameAt, Date.now())) {
       patch({ lastError: 'no heartbeat' })
       reconnectNow()
+      return
+    }
+    if (es && snapshot.phase !== 'open' && isStale(connectingAt, Date.now())) {
+      drop('connection timed out')
       return
     }
     if (!es && !reconnectTimer) connect()

--- a/src/lib/useActivityLive.tsx
+++ b/src/lib/useActivityLive.tsx
@@ -16,11 +16,10 @@ import {
   activityLiveInvalidateKeys,
   activityLiveStreamPath,
   needsActivityLiveStream,
+  createActivityBatch,
   type ActivityLiveEvent,
 } from './activityLive.ts'
 import { openLiveStream } from './liveStream.ts'
-
-const INVALIDATE_DEBOUNCE_MS = 100
 
 const ActivityLiveContext = createContext(false)
 
@@ -49,21 +48,9 @@ function useActivityLiveConnection(): boolean {
     }
     if (typeof EventSource === 'undefined') return
 
-    let invalidateTimer: ReturnType<typeof setTimeout> | null = null
-    let pendingKeys = new Set<string>()
-
-    const bump = (keys: readonly (readonly string[])[]) => {
-      if (keys.length === 0) return
-      for (const key of keys) pendingKeys.add(key.join('\0'))
-      if (invalidateTimer) clearTimeout(invalidateTimer)
-      invalidateTimer = setTimeout(() => {
-        const batch = [...pendingKeys]
-        pendingKeys = new Set()
-        for (const packed of batch) {
-          void qc.invalidateQueries({ queryKey: packed.split('\0') })
-        }
-      }, INVALIDATE_DEBOUNCE_MS)
-    }
+    const batch = createActivityBatch((queryKey) => {
+      void qc.invalidateQueries({ queryKey })
+    })
 
     const stream = openLiveStream({
       id: 'activity',
@@ -72,7 +59,7 @@ function useActivityLiveConnection(): boolean {
       onHealthyChange: setStreamHealthy,
       // Frames published while the socket was down are not replayed, so a
       // reconnect refetches rather than trusting what the cache still holds.
-      onResume: () => bump(ACTIVITY_LIVE_RESUME_KEYS),
+      onResume: () => batch.bump(ACTIVITY_LIVE_RESUME_KEYS),
       onMessage: (data) => {
         let event: ActivityLiveEvent
         try {
@@ -82,14 +69,14 @@ function useActivityLiveConnection(): boolean {
           return false
         }
         if (event.type === 'ping' || event.type === 'hello') return false
-        bump(activityLiveInvalidateKeys(event))
+        batch.bump(activityLiveInvalidateKeys(event))
         return true
       },
     })
 
     return () => {
       stream.close()
-      if (invalidateTimer) clearTimeout(invalidateTimer)
+      batch.close()
     }
   }, [enabled, qc])
 

--- a/src/routes/runs.$runId.tsx
+++ b/src/routes/runs.$runId.tsx
@@ -644,8 +644,6 @@ function RunDetail() {
               reviewPath={reviewPath}
               undoDisabled={runBusy}
               undoDisabledReason={undoFilesReason}
-              terminalOpen={layout.terminalOpen}
-              onToggleTerminal={() => patchLayout({ terminalOpen: !layout.terminalOpen })}
               onToggleRightPanel={() => patchLayout({ rightPanelOpen: false, maximized: false })}
               maximized={layout.maximized}
               onToggleMaximized={() =>


### PR DESCRIPTION
## Summary
- Unsaved workspace editor changes now survive background file refetches and save cleanly while typing continues
- Live streams recover from connections that stall before opening, and activity refreshes remain bounded during sustained event bursts
- Development no longer installs unused TanStack devtools, and the supported Node floor is explicit

## Test plan
- [ ] Open a file from a run workspace, edit it without saving, trigger a refetch, and confirm the draft remains intact
- [ ] Put the machine to sleep with `/runs` open, resume it, and confirm activity updates recover without a reload
- [ ] Keep a run producing frequent activity and confirm the runs list refreshes continuously rather than waiting for activity to stop