### PR TITLE
feat(tasks): add base ref picker to automation form

### DIFF
--- a/changelog.d/automation-base-ref-picker.md
+++ b/changelog.d/automation-base-ref-picker.md
@@ -1,3 +1,7 @@
 - You no longer type an automation's base branch into a plain text field. The
   form now offers the same searchable branch menu as the composer, and you can
   pick a tag or commit when it is not listed.
+
+- Workspace readiness no longer sits above the automation steps. It collapses
+  below them, opens automatically when something blocks a run, and shows a one-line
+  summary when folded.

--- a/changelog.d/automation-base-ref-picker.md
+++ b/changelog.d/automation-base-ref-picker.md
@@ -1,0 +1,3 @@
+- You no longer type an automation's base branch into a plain text field. The
+  form now offers the same searchable branch menu as the composer, and you can
+  pick a tag or commit when it is not listed.

--- a/src/components/ComposerControls.tsx
+++ b/src/components/ComposerControls.tsx
@@ -962,6 +962,130 @@ export function BranchPicker({
   )
 }
 
+export type BaseRefOption = {
+  name: string
+  /** Only a remote-tracking ref exists locally under this name. */
+  remote?: boolean
+  current?: boolean
+}
+
+/**
+ * Base revision an automation checks out for every run. Typed text is accepted
+ * as well as a listed branch: a tag or commit is a legitimate base, and
+ * `git for-each-ref` only answers branches.
+ */
+export function BaseRefPicker({
+  branches,
+  value,
+  defaultBranch,
+  disabled,
+  disabledReason,
+  invalid,
+  'aria-describedby': ariaDescribedBy,
+  onChange,
+}: {
+  branches: BaseRefOption[]
+  value: string
+  defaultBranch?: string
+  disabled?: boolean
+  disabledReason?: string
+  invalid?: boolean
+  'aria-describedby'?: string
+  onChange: (ref: string) => void
+}) {
+  const [filter, setFilter] = useState('')
+  const [visibleCount, setVisibleCount] = useState(BRANCH_PAGE_SIZE)
+  const query = filter.trim()
+  const matches = query
+    ? branches.filter((b) => b.name.toLowerCase().includes(query.toLowerCase()))
+    : branches
+  const visible = matches.slice(0, visibleCount)
+  const fallbackLabel = defaultBranch ? `${defaultBranch} (default)` : 'Default branch'
+
+  const pick = (ref: string, close: () => void) => {
+    onChange(ref)
+    close()
+  }
+
+  return (
+    <FooterMenu
+      label={truncateBranchLabel(value || fallbackLabel)}
+      title={disabledReason ?? (value || fallbackLabel)}
+      tooltip={disabledReason ?? 'Base revision every run starts from'}
+      disabled={disabled}
+      invalid={invalid}
+      aria-describedby={ariaDescribedBy}
+      leading={<GitBranch aria-hidden="true" className="h-3.5 w-3.5 shrink-0" />}
+      onOpen={() => {
+        setFilter('')
+        setVisibleCount(BRANCH_PAGE_SIZE)
+      }}
+    >
+      {(close) => (
+        <>
+          <div
+            onKeyDown={(event) => {
+              if (event.key !== 'Enter' || !query) return
+              event.preventDefault()
+              pick(query, close)
+            }}
+          >
+            <NavigationSearch
+              value={filter}
+              onChange={(next) => {
+                setFilter(next)
+                setVisibleCount(BRANCH_PAGE_SIZE)
+              }}
+              placeholder="Branch, tag or commit"
+              ariaLabel="Automation base branch or revision"
+            />
+          </div>
+          {query ? (
+            matches.some((b) => b.name === query) ? null : (
+              <MenuItem
+                label={`Use “${query}”`}
+                hint="Tag or commit"
+                leading={<Plus aria-hidden="true" className="h-3.5 w-3.5 shrink-0" />}
+                onSelect={() => pick(query, close)}
+              />
+            )
+          ) : (
+            <MenuItem
+              active={!value}
+              label={fallbackLabel}
+              hint="Follows the project default"
+              leading={<GitBranch aria-hidden="true" className="h-3.5 w-3.5 shrink-0" />}
+              onSelect={() => pick('', close)}
+            />
+          )}
+          {matches.length === 0 ? (
+            <div className="px-2.5 py-2 text-ui-base text-tier-quaternary">
+              {query ? 'No branch matches' : 'No branches yet'}
+            </div>
+          ) : null}
+          {visible.map((branch) => (
+            <MenuItem
+              key={branch.name}
+              active={branch.name === value}
+              label={branch.name}
+              hint={branch.remote ? 'Remote branch' : branch.current ? 'Checked out' : undefined}
+              leading={<GitBranch aria-hidden="true" className="h-3.5 w-3.5 shrink-0" />}
+              onSelect={() => pick(branch.name, close)}
+            />
+          ))}
+          <MenuListExpandToggle
+            totalCount={matches.length}
+            visibleCount={visibleCount}
+            pageSize={BRANCH_PAGE_SIZE}
+            expandLabel="More branches"
+            onVisibleCountChange={setVisibleCount}
+          />
+        </>
+      )}
+    </FooterMenu>
+  )
+}
+
 /** Saved CLI chats for one runtime, opened from its row in the runtime picker. */
 function RuntimeSessionSubmenu({
   group,

--- a/src/components/ComposerControls.tsx
+++ b/src/components/ComposerControls.tsx
@@ -40,6 +40,7 @@ import {
   toggleHiddenRuntime,
   visibleRuntimes,
 } from '../lib/pickRuntime'
+import { NavigationSearch } from './workspace/NavigationPicker'
 import { ProviderIcon } from './ProviderIcons'
 import { Tooltip } from './ui'
 

--- a/src/components/TaskForm.tsx
+++ b/src/components/TaskForm.tsx
@@ -83,6 +83,7 @@ import { missingRuntimeBinaryMessage } from '../lib/runtimeBinary'
 import { AddProjectModal } from './AddProjectModal'
 import { IntegrationBrandIcon } from './IntegrationCard'
 import {
+  BaseRefPicker,
   EffortPicker,
   FooterMenu,
   MenuItem,
@@ -1318,23 +1319,18 @@ export function TaskForm({
             |
           </span>
 
-          <label className="flex items-center gap-2 text-tier-tertiary">
-            Base
-            <input
-              aria-label="Automation base branch or revision"
-              list="automation-base-refs"
-              className="w-40 rounded border border-border bg-transparent px-2 py-1 text-foreground"
-              value={v.baseRef ?? ''}
-              placeholder={selectedProject?.defaultBranch || 'Default branch'}
-              disabled={!projectId || Boolean(workspaceChangeBlockedReason)}
-              onChange={(e) => set('baseRef', e.target.value)}
-            />
-            <datalist id="automation-base-refs">
-              {gitBranches?.map((b) => (
-                <option key={b.name} value={b.name} />
-              ))}
-            </datalist>
-          </label>
+          <BaseRefPicker
+            branches={gitBranches ?? []}
+            value={v.baseRef ?? ''}
+            disabled={!projectId || Boolean(workspaceChangeBlockedReason)}
+            {...(workspaceChangeBlockedReason
+              ? { disabledReason: workspaceChangeBlockedReason }
+              : {})}
+            {...(selectedProject?.defaultBranch
+              ? { defaultBranch: selectedProject.defaultBranch }
+              : {})}
+            onChange={(ref) => set('baseRef', ref)}
+          />
         </div>
         {nativeError ? <p className="mt-2 text-[12px] text-rose-300">{nativeError}</p> : null}
         {workspaceError ? (

--- a/src/components/TaskForm.tsx
+++ b/src/components/TaskForm.tsx
@@ -1367,18 +1367,6 @@ export function TaskForm({
       ) : null}
 
       <div className="space-y-7">
-        {workspaceChanged ? (
-          <Card className="mt-6 p-4">
-            <h2 className="text-ui-sm font-medium text-tier-secondary">Project Change Not Saved</h2>
-            <p className="mt-1 text-ui-sm leading-relaxed text-tier-tertiary">
-              Save changes to validate {selectedBranch ? `“${selectedBranch}”` : 'this workspace'}.
-              Readiness will update from the new workspace immediately after saving.
-            </p>
-          </Card>
-        ) : (
-          readiness
-        )}
-
         <section>
           <StepLabel n={1}>What the agent should do</StepLabel>
           <div
@@ -1737,6 +1725,18 @@ export function TaskForm({
             />
           ) : null}
         </section>
+
+        {workspaceChanged ? (
+          <Card className="p-4">
+            <h2 className="text-ui-sm font-medium text-tier-secondary">Project Change Not Saved</h2>
+            <p className="mt-1 text-ui-sm leading-relaxed text-tier-tertiary">
+              Save changes to validate {selectedBranch ? `“${selectedBranch}”` : 'this workspace'}.
+              Readiness will update from the new workspace immediately after saving.
+            </p>
+          </Card>
+        ) : (
+          readiness
+        )}
 
         {save.isError ? (
           <p className="rounded-lg border border-rose-500/20 bg-rose-500/5 px-3 py-2 text-sm text-rose-300">

--- a/src/components/WorkspaceReadiness.tsx
+++ b/src/components/WorkspaceReadiness.tsx
@@ -8,6 +8,7 @@
  * another branch is invisible in any view that only prints one of them.
  */
 import { AlertTriangle, CheckCircle2, GitBranch, Loader2, RotateCcw, Split } from 'lucide-react'
+import { useState } from 'react'
 import type { TaskWithMeta } from '../fns'
 import { hasUnattendedTrigger } from '../lib/taskReadiness'
 import { taskWorkspaceChangeBlockedReason } from '../lib/taskIsolationGate'
@@ -62,165 +63,204 @@ export function WorkspaceReadiness({ task }: { task: TaskWithMeta }) {
   const pending =
     isolate.isPending || restore.isPending || baseline.isPending || clearQuarantine.isPending
 
+  const [open, setOpen] = useState(blocked)
+
   const onError = (err: unknown) => window.alert(err instanceof Error ? err.message : String(err))
 
+  const title = blocked
+    ? cannotRun
+      ? 'Cannot Run This Automation'
+      : 'Not Ready for Unattended Runs'
+    : hasUnattendedTrigger(task)
+      ? 'Ready for Unattended Runs'
+      : 'Ready to Run'
+
   return (
-    <Card className="mt-6 p-4">
-      <div className="mb-3 flex items-center gap-2">
-        {blocked ? (
-          <AlertTriangle className="h-4 w-4 text-danger" />
-        ) : (
-          <CheckCircle2 className="h-4 w-4 text-success" />
-        )}
-        <h2 className="text-ui-sm font-medium text-tier-secondary">
-          {blocked
-            ? cannotRun
-              ? 'Cannot Run This Automation'
-              : 'Not Ready for Unattended Runs'
-            : hasUnattendedTrigger(task)
-              ? 'Ready for Unattended Runs'
-              : 'Ready to Run'}
-        </h2>
-      </div>
-
-      {blocked ? (
-        <ul className="mb-3 space-y-1 text-ui-sm leading-relaxed text-tier-secondary">
-          {blockers.map((blocker, index) => (
-            <li key={`${blocker.id}-${index}`} className="flex gap-2">
-              <span aria-hidden className="text-danger">
-                •
-              </span>
-              <span>{blocker.message}</span>
-            </li>
-          ))}
-        </ul>
-      ) : null}
-
-      {workspaceUnavailable ? (
-        <p className="mb-3 text-ui-sm leading-relaxed text-tier-tertiary">
-          Choose another workspace above, open an existing branch in a new workspace, or create a
-          new branch and workspace from the same menu.
-        </p>
-      ) : null}
-
-      <div className="space-y-1">
-        <Row label="Workspace" value={health?.path ?? task.cwd} />
-        <Row
-          label="Kind"
-          value={task.workspaceKind === 'main' ? 'main checkout (shared)' : 'app-managed worktree'}
-          muted={task.workspaceKind !== 'main'}
-        />
-        <Row label="Configured branch" value={health?.configuredBranch ?? ''} />
-        <Row
-          label="Actual branch"
-          value={health?.actualBranch ?? ''}
-          muted={!health || health.actualBranch === health.configuredBranch}
-        />
-        <Row
-          label="Working tree"
-          value={health?.dirty ? 'has uncommitted changes' : 'clean'}
-          muted={!health?.dirty}
-        />
-        {task.requiresGh ? (
-          <Row
-            label="GitHub CLI"
-            value={
-              !task.ghInstalled
-                ? 'not installed'
-                : task.ghAuthenticated
-                  ? 'authenticated'
-                  : 'not authenticated'
-            }
-            muted={task.ghInstalled && task.ghAuthenticated}
-          />
-        ) : null}
-      </div>
-
-      <div className="mt-4 flex flex-wrap gap-2">
-        {sharedCheckout ? (
-          <Button
-            variant="primary"
-            disabled={pending || activityBlocked !== null}
-            onClick={() => isolate.mutate(task.id, { onError })}
-            title={activityBlocked ?? 'Create a worktree and branch for this automation alone'}
-          >
-            {isolate.isPending ? (
-              <Loader2 className="h-3.5 w-3.5 animate-spin" />
-            ) : (
-              <Split className="h-3.5 w-3.5" />
-            )}
-            Give it its own worktree
-          </Button>
-        ) : null}
-
-        {canRestore ? (
-          <Button
-            variant="ghost"
-            disabled={pending || activityBlocked !== null}
-            onClick={() => {
-              if (
-                !confirm(
-                  'Put this worktree back on its branch, discarding uncommitted changes and any commits it has not pushed?',
-                )
-              ) {
-                return
-              }
-              restore.mutate(task.id, { onError })
-            }}
-            title={activityBlocked ?? 'Reset the worktree and lift any quarantine'}
-          >
-            {restore.isPending ? (
-              <Loader2 className="h-3.5 w-3.5 animate-spin" />
-            ) : (
-              <RotateCcw className="h-3.5 w-3.5" />
-            )}
-            Restore workspace
-          </Button>
-        ) : null}
-
-        {quarantined ? (
-          <Button
-            variant="ghost"
-            disabled={pending || activityBlocked !== null}
-            onClick={() => clearQuarantine.mutate(task.id, { onError })}
-            title={activityBlocked ?? 'Keep the files, but stop refusing unattended runs here'}
-          >
-            {clearQuarantine.isPending ? (
-              <Loader2 className="h-3.5 w-3.5 animate-spin" />
-            ) : (
-              <CheckCircle2 className="h-3.5 w-3.5" />
-            )}
-            Clear quarantine
-          </Button>
-        ) : null}
-
+    <section>
+      <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
         <Button
+          type="button"
           variant="ghost"
-          disabled={pending || activityBlocked !== null || baselineBlocked !== null}
-          onClick={() =>
-            baseline.mutate(task.workspaceId, {
-              onError,
-              onSuccess: (result) => {
-                window.alert(
-                  result.ok ? 'Baseline is green — this workspace is safe to arm.' : result.detail,
-                )
-              },
-            })
-          }
-          title={
-            activityBlocked ??
-            baselineBlocked ??
-            "Run the project's checks here before arming anything against it"
-          }
+          aria-expanded={open}
+          onClick={() => setOpen((v) => !v)}
         >
-          {baseline.isPending ? (
-            <Loader2 className="h-3.5 w-3.5 animate-spin" />
+          {blocked ? (
+            <AlertTriangle className="h-3.5 w-3.5 text-danger" />
           ) : (
-            <GitBranch className="h-3.5 w-3.5" />
+            <CheckCircle2 className="h-3.5 w-3.5 text-success" />
           )}
-          Run baseline checks
+          {title}
         </Button>
+        {!open ? (
+          <span className="text-ui-sm text-tier-quaternary">
+            {readinessSummary(task, blockers)}
+          </span>
+        ) : null}
       </div>
-    </Card>
+
+      {!open ? null : (
+        <Card className="mt-2 p-4">
+          {blocked ? (
+            <ul className="mb-3 space-y-1 text-ui-sm leading-relaxed text-tier-secondary">
+              {blockers.map((blocker, index) => (
+                <li key={`${blocker.id}-${index}`} className="flex gap-2">
+                  <span aria-hidden className="text-danger">
+                    •
+                  </span>
+                  <span>{blocker.message}</span>
+                </li>
+              ))}
+            </ul>
+          ) : null}
+
+          {workspaceUnavailable ? (
+            <p className="mb-3 text-ui-sm leading-relaxed text-tier-tertiary">
+              Choose another workspace above, open an existing branch in a new workspace, or create
+              a new branch and workspace from the same menu.
+            </p>
+          ) : null}
+
+          <div className="space-y-1">
+            <Row label="Workspace" value={health?.path ?? task.cwd} />
+            <Row
+              label="Kind"
+              value={
+                task.workspaceKind === 'main' ? 'main checkout (shared)' : 'app-managed worktree'
+              }
+              muted={task.workspaceKind !== 'main'}
+            />
+            <Row label="Configured branch" value={health?.configuredBranch ?? ''} />
+            <Row
+              label="Actual branch"
+              value={health?.actualBranch ?? ''}
+              muted={!health || health.actualBranch === health.configuredBranch}
+            />
+            <Row
+              label="Working tree"
+              value={health?.dirty ? 'has uncommitted changes' : 'clean'}
+              muted={!health?.dirty}
+            />
+            {task.requiresGh ? (
+              <Row
+                label="GitHub CLI"
+                value={
+                  !task.ghInstalled
+                    ? 'not installed'
+                    : task.ghAuthenticated
+                      ? 'authenticated'
+                      : 'not authenticated'
+                }
+                muted={task.ghInstalled && task.ghAuthenticated}
+              />
+            ) : null}
+          </div>
+
+          <div className="mt-4 flex flex-wrap gap-2">
+            {sharedCheckout ? (
+              <Button
+                variant="primary"
+                disabled={pending || activityBlocked !== null}
+                onClick={() => isolate.mutate(task.id, { onError })}
+                title={activityBlocked ?? 'Create a worktree and branch for this automation alone'}
+              >
+                {isolate.isPending ? (
+                  <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                ) : (
+                  <Split className="h-3.5 w-3.5" />
+                )}
+                Give it its own worktree
+              </Button>
+            ) : null}
+
+            {canRestore ? (
+              <Button
+                variant="ghost"
+                disabled={pending || activityBlocked !== null}
+                onClick={() => {
+                  if (
+                    !confirm(
+                      'Put this worktree back on its branch, discarding uncommitted changes and any commits it has not pushed?',
+                    )
+                  ) {
+                    return
+                  }
+                  restore.mutate(task.id, { onError })
+                }}
+                title={activityBlocked ?? 'Reset the worktree and lift any quarantine'}
+              >
+                {restore.isPending ? (
+                  <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                ) : (
+                  <RotateCcw className="h-3.5 w-3.5" />
+                )}
+                Restore workspace
+              </Button>
+            ) : null}
+
+            {quarantined ? (
+              <Button
+                variant="ghost"
+                disabled={pending || activityBlocked !== null}
+                onClick={() => clearQuarantine.mutate(task.id, { onError })}
+                title={activityBlocked ?? 'Keep the files, but stop refusing unattended runs here'}
+              >
+                {clearQuarantine.isPending ? (
+                  <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                ) : (
+                  <CheckCircle2 className="h-3.5 w-3.5" />
+                )}
+                Clear quarantine
+              </Button>
+            ) : null}
+
+            <Button
+              variant="ghost"
+              disabled={pending || activityBlocked !== null || baselineBlocked !== null}
+              onClick={() =>
+                baseline.mutate(task.workspaceId, {
+                  onError,
+                  onSuccess: (result) => {
+                    window.alert(
+                      result.ok
+                        ? 'Baseline is green — this workspace is safe to arm.'
+                        : result.detail,
+                    )
+                  },
+                })
+              }
+              title={
+                activityBlocked ??
+                baselineBlocked ??
+                "Run the project's checks here before arming anything against it"
+              }
+            >
+              {baseline.isPending ? (
+                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+              ) : (
+                <GitBranch className="h-3.5 w-3.5" />
+              )}
+              Run baseline checks
+            </Button>
+          </div>
+        </Card>
+      )}
+    </section>
   )
+}
+
+/**
+ * Collapsed line: why it is blocked, or what the run would use.
+ */
+function readinessSummary(
+  task: TaskWithMeta,
+  blockers: NonNullable<TaskWithMeta['readinessBlockers']>,
+): string {
+  if (blockers.length > 0) {
+    return blockers.length === 1
+      ? (blockers[0]?.message ?? '1 blocker')
+      : `${blockers.length} blockers`
+  }
+  const kind = task.workspaceKind === 'main' ? 'main checkout (shared)' : 'app-managed worktree'
+  const branch = task.workspaceHealth?.actualBranch ?? task.workspaceHealth?.configuredBranch ?? ''
+  return branch ? `${kind} · ${branch}` : kind
 }


### PR DESCRIPTION
## Summary
- Automations now pick their base revision from a searchable branch menu instead of a plain text field with datalist hints.
- You can enter a tag or commit when it is not in the branch list, including via Enter in the search box.

## Test plan
- [ ] Open `/tasks/new`, select a project, and open the Base picker — listed branches appear and the default branch option clears the field
- [ ] Type a commit SHA or tag that is not in the list and choose "Use …" (or press Enter) — the value saves on the automation
- [ ] Edit an existing automation with a custom base ref — the picker shows the saved value and workspace-change blocking still disables it with the same reason

Made with [Cursor](https://cursor.com)