### PR TITLE
feat(highlight): serve syntax classes to native clients

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -212,6 +212,7 @@ Neither hook may open an `EventSource` of its own.
 | Diffs, commit/push/branch/PR, base snapshots | `server/git.ts`; UI in `components/GitActions.tsx`, `components/DiffPanel.tsx`, `lib/diff.ts` |
 | Undoing a run — files vs. the commits it made | `lib/undoRun.ts` (the rule), `git.runCommits` / `git.resetRunCommits`, `core.discardChanges`; the dialog lives in `routes/runs.$runId.tsx` |
 | How a diff line looks (git panel **and** chat edit hunks) | `components/DiffRows.tsx`; tokens from `lib/highlight.ts`; agent-supplied hunks via `lib/lineDiff.ts` |
+| Syntax colour: which grammar, and colouring for a non-TypeScript client | `lib/languageSupport.ts` (extension → grammar), `lib/highlight.ts` (`highlightSnippet`, the caps); served to native clients by the `code.highlight` operation, which answers `hl-*` class names, never colours |
 | Workspace file browse/edit (path-traversal trust boundary) | `server/files.ts` |
 | Webhooks (relayed from the control plane) | `server/integrations/`, `lib/integrations/`, `routes/integrations.tsx` (layout) · `integrations.index.tsx` · `integrations.$provider.tsx` |
 | Connecting a provider: what the panel offers and why | `lib/cloud/providers.ts` (the gate) → `components/IntegrationConnect.tsx`; the catalog it reads comes from `server/cloud/providers.ts` |

--- a/changelog.d/desktop-code-highlight.md
+++ b/changelog.d/desktop-code-highlight.md
@@ -1,0 +1,5 @@
+- A native client no longer has to ship its own grammars to colour code. Open
+  Run tokenizes a snippet on request with the same highlighter the web
+  transcript uses, answering the `hl-*` class names rather than colours, so the
+  desktop app paints the identical syntax without a second set of parsers that
+  could drift from ours.

--- a/clients/apple/OpenRunKit/Sources/OpenRunKit/Generated.swift
+++ b/clients/apple/OpenRunKit/Sources/OpenRunKit/Generated.swift
@@ -35,6 +35,8 @@ public enum Operation: String, CaseIterable, Sendable {
     case filesRestoreWorkspace = "files.restoreWorkspace"
     /// Upload a composer image; `data` is raw base64 without the data-URL prefix.
     case filesSaveAttachment = "files.saveAttachment"
+    /// Tokenize a snippet with the app's own highlighter; answers class names, not colours.
+    case codeHighlight = "code.highlight"
     case gitGetFileDiff = "git.getFileDiff"
     case gitCommitChanges = "git.commitChanges"
     case gitPushChanges = "git.pushChanges"
@@ -167,6 +169,7 @@ public enum Operation: String, CaseIterable, Sendable {
         case .filesWriteWorkspace: return Route(method: "POST", path: "/api/v1/files/write-workspace", capability: "files.writeWorkspace", clients: ["web", "desktop"])
         case .filesRestoreWorkspace: return Route(method: "POST", path: "/api/v1/files/restore-workspace", capability: "files.restoreWorkspace", clients: ["web", "desktop"])
         case .filesSaveAttachment: return Route(method: "POST", path: "/api/v1/files/save-attachment", capability: "files.saveAttachment", clients: ["web", "desktop"])
+        case .codeHighlight: return Route(method: "POST", path: "/api/v1/code/highlight", capability: "code.highlight", clients: ["desktop"])
         case .gitGetFileDiff: return Route(method: "GET", path: "/api/v1/git/get-file-diff", capability: "runs.diff", clients: ["web", "desktop", "mobile"])
         case .gitCommitChanges: return Route(method: "POST", path: "/api/v1/git/commit-changes", capability: "git.commitChanges", clients: ["web", "desktop"])
         case .gitPushChanges: return Route(method: "POST", path: "/api/v1/git/push-changes", capability: "git.pushChanges", clients: ["web", "desktop"])
@@ -422,6 +425,19 @@ public struct FilesSaveAttachmentRequest: Encodable, Sendable {
         self.name = name
         self.mimeType = mimeType
         self.data = data
+    }
+}
+
+/// Tokenize a snippet with the app's own highlighter; answers class names, not colours.
+public struct CodeHighlightRequest: Encodable, Sendable {
+    public var code: String
+    public var language: String?
+    public var path: String?
+
+    public init(code: String, language: String? = nil, path: String? = nil) {
+        self.code = code
+        self.language = language
+        self.path = path
     }
 }
 

--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -35,6 +35,7 @@ import {
   usePlugins,
   useRestoreFile,
   useSlashCommands,
+  useConversationNavigationRuns,
 } from '../lib/queries'
 import * as fns from '../fns'
 import { DEFAULT_RUNTIME_MODE, type RuntimeMode } from '../lib/runtimeMode'
@@ -800,6 +801,7 @@ export function Chat({
   onNewChat,
   pullRequest,
   repositoryUrl,
+  returnToHome = false,
 }: {
   messages: ChatMessage[]
   /** Pulse the transcript scroller while conversation is still in flight. */
@@ -880,6 +882,8 @@ export function Chat({
   pullRequest?: RunPullRequest | null
   /** Repository remote used to resolve plain `PR #123` mentions. */
   repositoryUrl?: string
+  /** Preserve the page that opened this conversation when navigating between runs. */
+  returnToHome?: boolean
 }) {
   const bottomRef = useRef<HTMLDivElement>(null)
   const scrollerRef = useRef<HTMLDivElement>(null)
@@ -905,6 +909,7 @@ export function Chat({
   const queuedMessages = queued ?? []
 
   const runtimeCatalog = useMemo(() => runtimes ?? [], [runtimes])
+  const { data: navigationRuns = [] } = useConversationNavigationRuns()
   // A handoff is only pending until the turn is sent; once the run row moves,
   // `runtimeId` comes back as the new runtime and this is false again.
   const switching = isRuntimeSwitch(runtimeId, selectedRuntimeId)
@@ -1277,15 +1282,32 @@ export function Chat({
                     }
                   : {})}
                 {...(phase ? { runningLabel: `${phase.label}…` } : {})}
-                {...(canSwitchRuntime && runtimeCatalog.length > 0 && selectedRuntimeId
+                {...((canSwitchRuntime || navigationRuns.length > 0) &&
+                runtimeCatalog.length > 0 &&
+                selectedRuntimeId
                   ? {
                       leading: (
                         <div className="flex min-w-0 shrink items-center gap-0.5">
                           <RuntimePicker
                             runtimes={runtimeCatalog}
                             runtimeId={selectedRuntimeId}
-                            disabled={pending || running}
+                            disabled={pending}
+                            disableRuntimeSelection={!canSwitchRuntime}
                             align="start"
+                            conversations={{
+                              runs: navigationRuns.filter(
+                                (run) => run.projectId === installProjectId,
+                              ),
+                              currentRunId: runId,
+                              workspaceId: workspaceId ?? '',
+                              projectId: installProjectId ?? '',
+                              onSelect: (nextRunId) =>
+                                navigate({
+                                  to: '/runs/$runId',
+                                  params: { runId: nextRunId },
+                                  search: returnToHome ? { from: 'home' } : {},
+                                }),
+                            }}
                             onChange={handleRuntimePick}
                           />
                         </div>

--- a/src/components/ComposerControls.tsx
+++ b/src/components/ComposerControls.tsx
@@ -15,7 +15,6 @@ import {
   EyeOff,
   FolderGit2,
   GitBranch,
-  MessageSquare,
   Plus,
 } from 'lucide-react'
 import {
@@ -34,9 +33,11 @@ import { relativeTime } from '../lib/format'
 import type { NativeSession, NativeSessionGroup } from '../lib/nativeSessions'
 import { useNativeSessionPaging } from '../hooks/useNativeSessionPaging'
 import { truncateBranchLabel, truncateNavTitle } from '../lib/truncateLabel'
+import { groupThreadLensRuns, type ThreadLensRun } from '../lib/threadLens'
+import { NavigationItem, NavigationSearch } from './workspace/NavigationPicker'
 import {
   hiddenRuntimesIn,
-  installedRuntimes,
+  isAlwaysVisibleRuntime,
   toggleHiddenRuntime,
   visibleRuntimes,
 } from '../lib/pickRuntime'
@@ -238,6 +239,7 @@ export function FooterMenu({
 
 export function MenuItem({
   active,
+  showActiveIndicator = true,
   disabled,
   label,
   hint,
@@ -245,6 +247,7 @@ export function MenuItem({
   onSelect,
 }: {
   active?: boolean
+  showActiveIndicator?: boolean
   disabled?: boolean
   label: string
   hint?: string
@@ -271,7 +274,9 @@ export function MenuItem({
           <span className="block truncate text-ui-sm text-tier-quaternary">{hint}</span>
         ) : null}
       </span>
-      {active ? <Check className="h-3.5 w-3.5 shrink-0 text-tier-secondary" /> : null}
+      {active && showActiveIndicator ? (
+        <Check className="h-3.5 w-3.5 shrink-0 text-tier-secondary" />
+      ) : null}
     </button>
   )
 }
@@ -337,6 +342,7 @@ function HideableMenuItem({
   hint,
   leading,
   active,
+  disabled = false,
   hidden,
   hideTitle,
   showTitle,
@@ -352,6 +358,7 @@ function HideableMenuItem({
   hint?: string
   leading?: ReactNode
   active: boolean
+  disabled?: boolean
   hidden: boolean
   hideTitle: string
   showTitle: string
@@ -378,6 +385,7 @@ function HideableMenuItem({
         {...(hasSubmenu ? { 'aria-haspopup': 'menu' as const, 'aria-expanded': submenuOpen } : {})}
         onFocus={onPointerEnter}
         onClick={onSelect}
+        disabled={disabled}
         className={`flex min-w-0 flex-1 items-center gap-2.5 rounded-lg px-2.5 py-2 text-left text-ui-base transition-colors hover:bg-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring/60 ${
           active || submenuOpen ? 'text-foreground' : 'text-foreground/85 hover:text-foreground'
         } ${hidden ? 'opacity-55' : ''}`}
@@ -391,12 +399,6 @@ function HideableMenuItem({
             <span className="block truncate text-ui-sm text-tier-quaternary">{hint}</span>
           ) : null}
         </span>
-        {active ? (
-          <Check aria-hidden="true" className="h-3.5 w-3.5 shrink-0 text-tier-secondary" />
-        ) : null}
-        {hasSubmenu ? (
-          <ChevronRight aria-hidden="true" className="h-3.5 w-3.5 shrink-0 text-tier-quaternary" />
-        ) : null}
       </button>
       <button
         type="button"
@@ -404,12 +406,22 @@ function HideableMenuItem({
         title={hidden ? showTitle : hideTitle}
         aria-label={hidden ? showTitle : hideTitle}
         onClick={onToggleHidden}
-        className="mr-0.5 flex size-8 shrink-0 items-center justify-center rounded-md text-tier-quaternary opacity-60 transition-[color,background-color,opacity] hover:bg-hover hover:text-foreground hover:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/60"
+        className="group/action mr-0.5 flex size-8 shrink-0 items-center justify-center rounded-md text-tier-quaternary opacity-60 transition-[color,background-color,opacity] hover:bg-hover hover:text-foreground hover:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/60"
       >
+        <ChevronRight
+          aria-hidden="true"
+          className="h-3.5 w-3.5 group-hover/action:hidden group-focus-visible/action:hidden"
+        />
         {hidden ? (
-          <Eye aria-hidden="true" className="h-3.5 w-3.5" />
+          <Eye
+            aria-hidden="true"
+            className="hidden h-3.5 w-3.5 group-hover/action:block group-focus-visible/action:block"
+          />
         ) : (
-          <EyeOff aria-hidden="true" className="h-3.5 w-3.5" />
+          <EyeOff
+            aria-hidden="true"
+            className="hidden h-3.5 w-3.5 group-hover/action:block group-focus-visible/action:block"
+          />
         )}
       </button>
     </div>
@@ -969,26 +981,50 @@ function RuntimeSessionSubmenu({
   submenuRef,
   resumeSessionId,
   loading,
-  hideNewConversation,
   onHover,
   onLeave,
-  onSelectNew,
   onSelect,
   onLoadMore,
+  conversations,
 }: {
-  group: NativeSessionGroup
+  group?: NativeSessionGroup
+  conversations?: {
+    runs: ThreadLensRun[]
+    currentRunId: string
+    workspaceId: string
+    projectId: string
+    onIntent?: (runId: string) => void
+    onSelect: (runId: string) => unknown
+  }
   anchor: HTMLElement | null
   submenuRef: RefObject<HTMLDivElement | null>
   resumeSessionId: string
   loading: boolean
-  hideNewConversation?: boolean
   onHover: () => void
   onLeave: () => void
-  onSelectNew: () => void
   onSelect: (session: NativeSession) => void
   onLoadMore: () => void
 }) {
   const [coords, setCoords] = useState<{ top: number; left: number } | null>(null)
+  const [query, setQuery] = useState('')
+  const inputRef = useRef<HTMLInputElement>(null)
+  const nativeSessions =
+    group?.sessions.filter((session) => {
+      const needle = query.trim().toLocaleLowerCase()
+      return (
+        !needle ||
+        session.title.toLocaleLowerCase().includes(needle) ||
+        session.projectName?.toLocaleLowerCase().includes(needle)
+      )
+    }) ?? []
+
+  const conversationGroups = conversations
+    ? groupThreadLensRuns(
+        conversations.runs,
+        { workspaceId: conversations.workspaceId, projectId: conversations.projectId },
+        query,
+      )
+    : []
 
   useLayoutEffect(() => {
     if (!anchor) {
@@ -1011,7 +1047,11 @@ function RuntimeSessionSubmenu({
       window.removeEventListener('resize', update)
       window.removeEventListener('scroll', update, true)
     }
-  }, [anchor, group.sessions.length, loading])
+  }, [anchor, group?.sessions.length, loading])
+
+  useEffect(() => {
+    if (coords) inputRef.current?.focus()
+  }, [coords])
 
   return createPortal(
     <div
@@ -1026,34 +1066,89 @@ function RuntimeSessionSubmenu({
         zIndex: 401,
         visibility: coords ? 'visible' : 'hidden',
       }}
-      className="max-h-80 w-80 overflow-auto rounded-xl border border-border bg-elevated p-1 shadow-xl shadow-black/40"
+      className="max-h-[min(30rem,65vh)] w-80 overflow-auto rounded-xl border border-border bg-elevated p-1 shadow-xl shadow-black/40"
     >
-      {!hideNewConversation ? (
-        <MenuItem
-          active={!resumeSessionId}
-          label="New conversation"
-          leading={<MessageSquare className="h-3.5 w-3.5 shrink-0" />}
-          onSelect={onSelectNew}
+      <div className="border-b border-border pb-1">
+        <NavigationSearch
+          value={query}
+          onChange={setQuery}
+          placeholder="Search conversations..."
+          ariaLabel="Search conversations"
+          inputRef={inputRef}
         />
-      ) : null}
-      {group.sessions.length === 0 ? (
-        <p className="px-2.5 py-2 text-ui-sm text-tier-quaternary">No {group.label} chats yet.</p>
-      ) : (
-        group.sessions.map((session) => (
-          <MenuItem
+      </div>
+      {group && nativeSessions.length > 0 ? (
+        nativeSessions.map((session) => (
+          <NavigationItem
             key={`${session.workspaceId ?? ''}:${session.sessionId}`}
             active={session.sessionId === resumeSessionId}
+            showActiveIndicator={false}
             label={session.title}
             hint={`${relativeTime(session.modifiedAt)}${
               session.messageCount
                 ? ` · ${session.messageCount} message${session.messageCount === 1 ? '' : 's'}`
                 : ''
             }${session.projectName ? ` · ${session.projectName}` : ''}`}
+            icon={
+              <ProviderIcon
+                kind={modelKindForBin(group.bin || group.runtimeId)}
+                className="size-3.5 shrink-0"
+              />
+            }
             onSelect={() => onSelect(session)}
           />
         ))
-      )}
-      {group.hasMore ? (
+      ) : group && !conversations ? (
+        <p className="px-2.5 py-2 text-ui-sm text-tier-quaternary">
+          {query.trim() ? 'No conversations found' : `No ${group.label} chats yet.`}
+        </p>
+      ) : null}
+      {conversations ? (
+        <>
+          {conversationGroups
+            .flatMap((conversationGroup) => conversationGroup.runs)
+            .map((run) => (
+              <NavigationItem
+                key={run.id}
+                label={truncateNavTitle(run.chatTitle)}
+                icon={
+                  <ProviderIcon
+                    kind={modelKindForBin(run.runtimeId)}
+                    className="size-3.5 shrink-0"
+                  />
+                }
+                active={run.id === conversations.currentRunId}
+                showActiveIndicator={false}
+                unread={run.unread}
+                onPointerDown={() => conversations.onIntent?.(run.id)}
+                onPointerEnter={() => conversations.onIntent?.(run.id)}
+                onFocus={() => conversations.onIntent?.(run.id)}
+                meta={
+                  <span className="flex items-center gap-1.5 text-[11px] text-muted-foreground">
+                    {relativeTime(run.startedAt).replace(' ago', '')}
+                  </span>
+                }
+                onSelect={() => conversations.onSelect(run.id)}
+                onClick={(event) => {
+                  if (event.metaKey || event.ctrlKey) {
+                    event.preventDefault()
+                    window.open(
+                      `/runs/${encodeURIComponent(run.id)}`,
+                      '_blank',
+                      'noopener,noreferrer',
+                    )
+                    return
+                  }
+                  conversations.onSelect(run.id)
+                }}
+              />
+            ))}
+          {conversationGroups.length === 0 && nativeSessions.length === 0 ? (
+            <p className="px-2.5 py-2 text-ui-sm text-tier-quaternary">No conversations found</p>
+          ) : null}
+        </>
+      ) : null}
+      {group?.hasMore ? (
         <button
           type="button"
           onClick={onLoadMore}
@@ -1072,28 +1167,39 @@ export function RuntimePicker({
   runtimes,
   runtimeId,
   disabled,
+  disableRuntimeSelection = false,
   align = 'end',
   initiallyOpen,
   keepOpen,
   sessions,
+  conversations,
   onChange,
 }: {
   runtimes: RuntimeOption[]
   runtimeId: string
   disabled?: boolean
+  /** Keep child conversation links usable while runtime switching is unavailable. */
+  disableRuntimeSelection?: boolean
   align?: 'start' | 'end'
   initiallyOpen?: boolean
   keepOpen?: boolean
   /** Adds a saved-chats submenu to every runtime that can resume one. */
   sessions?: {
     workspaceId: string
-    allWorkspaces?: boolean
     groups: NativeSessionGroup[]
     resumeSessionId: string
     resumeSessionLabel: string
     onOpen?: () => unknown
     onSelectNew: () => void
     onSelect: (session: NativeSession, group: NativeSessionGroup) => void
+  }
+  conversations?: {
+    runs: ThreadLensRun[]
+    currentRunId: string
+    workspaceId: string
+    projectId: string
+    onIntent?: (runId: string) => void
+    onSelect: (runId: string) => unknown
   }
   onChange: (id: string) => void
 }) {
@@ -1106,7 +1212,6 @@ export function RuntimePicker({
   const { mergedGroups, loadingKind, loadMore } = useNativeSessionPaging(
     sessions?.workspaceId ?? '',
     sessions?.groups ?? [],
-    sessions?.allWorkspaces,
   )
 
   const clearCloseTimer = () => {
@@ -1127,7 +1232,7 @@ export function RuntimePicker({
 
   if (runtimes.length === 0) return null
   const selected = runtimes.find((r) => r.id === runtimeId) ?? runtimes[0]!
-  const present = installedRuntimes(runtimes, selected.id)
+  const present = runtimes
   const shown = visibleRuntimes(present, prefs.hiddenRuntimes, selected.id)
   const hidden = hiddenRuntimesIn(present, prefs.hiddenRuntimes, selected.id)
   const explicitlyHidden = new Set(prefs.hiddenRuntimes ?? [])
@@ -1135,7 +1240,10 @@ export function RuntimePicker({
     remember({ hiddenRuntimes: toggleHiddenRuntime(prefs.hiddenRuntimes, id) })
 
   const groupFor = (id: string) => mergedGroups.find((g) => g.runtimeId === id)
+  const openRuntime = openSubmenuId ? runtimes.find((r) => r.id === openSubmenuId) : undefined
   const openGroup = openSubmenuId ? groupFor(openSubmenuId) : undefined
+  const conversationsFor = (id: string) =>
+    conversations?.runs.filter((run) => run.runtimeId === id) ?? []
   const resumeLabel =
     sessions?.resumeSessionId &&
     groupFor(selected.id)?.sessions.find((s) => s.sessionId === sessions.resumeSessionId)?.title
@@ -1158,6 +1266,8 @@ export function RuntimePicker({
         <>
           {(showHidden ? present : shown).map((r) => {
             const group = groupFor(r.id)
+            const runtimeConversations = conversationsFor(r.id)
+            const hasChildren = Boolean(group) || runtimeConversations.length > 0
             return (
               <HideableMenuItem
                 key={r.id}
@@ -1165,13 +1275,18 @@ export function RuntimePicker({
                 hint={r.bin}
                 leading={<ProviderIcon kind={runtimeIconKind(r)} className="size-4 shrink-0" />}
                 active={r.id === selected.id}
-                hidden={explicitlyHidden.has(r.id)}
-                hideTitle={`Hide ${r.label} from this list`}
+                disabled={disableRuntimeSelection}
+                hidden={explicitlyHidden.has(r.id) && !isAlwaysVisibleRuntime(r.id)}
+                hideTitle={
+                  isAlwaysVisibleRuntime(r.id)
+                    ? `${r.label} is always shown`
+                    : `Hide ${r.label} from this list`
+                }
                 showTitle={`Show ${r.label} again`}
                 rowRef={(el) => {
                   rowRefs.current[r.id] = el
                 }}
-                {...(group
+                {...(hasChildren
                   ? {
                       hasSubmenu: true,
                       submenuOpen: openSubmenuId === r.id,
@@ -1181,6 +1296,7 @@ export function RuntimePicker({
                   : { onPointerEnter: deferCloseSubmenu })}
                 onSelect={() => {
                   onChange(r.id)
+                  sessions?.onSelectNew()
                   close()
                 }}
                 onToggleHidden={() => toggleHidden(r.id)}
@@ -1202,28 +1318,33 @@ export function RuntimePicker({
               {showHidden ? 'Hide hidden runtimes' : `${hidden.length} hidden`}
             </button>
           ) : null}
-          {sessions && openGroup ? (
+          {(sessions && openGroup) ||
+          (conversations && openRuntime && conversationsFor(openRuntime.id).length > 0) ? (
             <RuntimeSessionSubmenu
-              group={openGroup}
-              anchor={rowRefs.current[openGroup.runtimeId] ?? null}
+              {...(openGroup ? { group: openGroup } : {})}
+              {...(conversations && openRuntime
+                ? {
+                    conversations: {
+                      ...conversations,
+                      runs: conversationsFor(openRuntime.id),
+                    },
+                  }
+                : {})}
+              anchor={rowRefs.current[openRuntime?.id ?? ''] ?? null}
               submenuRef={submenuRef}
-              resumeSessionId={sessions.resumeSessionId}
-              loading={loadingKind === openGroup.kind}
-              hideNewConversation={sessions.allWorkspaces}
-              onHover={() => openSubmenu(openGroup.runtimeId)}
+              resumeSessionId={sessions?.resumeSessionId ?? ''}
+              loading={openGroup ? loadingKind === openGroup.kind : false}
+              onHover={() => openSubmenu(openRuntime?.id ?? '')}
               onLeave={deferCloseSubmenu}
-              onSelectNew={() => {
-                onChange(openGroup.runtimeId)
-                sessions.onSelectNew()
-                setOpenSubmenuId(null)
-                close()
-              }}
               onSelect={(session) => {
+                if (!openGroup || !sessions) return
                 sessions.onSelect(session, openGroup)
                 setOpenSubmenuId(null)
                 close()
               }}
-              onLoadMore={() => void loadMore(openGroup.kind)}
+              onLoadMore={() => {
+                if (openGroup) void loadMore(openGroup.kind)
+              }}
             />
           ) : null}
         </>

--- a/src/components/InstallBanner.tsx
+++ b/src/components/InstallBanner.tsx
@@ -1,0 +1,123 @@
+import { Download, X } from 'lucide-react'
+import { useEffect, useState } from 'react'
+
+const DISMISSED_KEY = 'openrun:install-banner-dismissed'
+
+type InstallPromptEvent = Event & {
+  prompt: () => Promise<void>
+  userChoice: Promise<{ outcome: 'accepted' | 'dismissed' }>
+}
+
+type InstallMode = 'chrome' | 'safari' | null
+
+function browserInstallMode(): InstallMode {
+  const ua = navigator.userAgent
+  const isIos =
+    /iPhone|iPad|iPod/.test(ua) ||
+    (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1)
+  if (isIos) return 'safari'
+
+  const isSafari = /Safari/.test(ua) && !/Chrome|CriOS|FxiOS|EdgiOS|OPiOS|Android/.test(ua)
+  if (isSafari) return 'safari'
+
+  return /Chrome|CriOS/.test(ua) ? 'chrome' : null
+}
+
+function isInstalled(): boolean {
+  return (
+    window.matchMedia('(display-mode: standalone)').matches ||
+    (navigator as Navigator & { standalone?: boolean }).standalone === true
+  )
+}
+
+export function InstallBanner() {
+  const [mode, setMode] = useState<InstallMode>(null)
+  const [promptEvent, setPromptEvent] = useState<InstallPromptEvent | null>(null)
+  const [dismissed, setDismissed] = useState(false)
+
+  useEffect(() => {
+    if (isInstalled()) return
+    try {
+      if (localStorage.getItem(DISMISSED_KEY) === 'true') {
+        setDismissed(true)
+        return
+      }
+    } catch {
+      // Continue when storage is unavailable.
+    }
+
+    setMode(browserInstallMode())
+    const onBeforeInstallPrompt = (event: Event) => {
+      event.preventDefault()
+      setPromptEvent(event as InstallPromptEvent)
+      setMode('chrome')
+    }
+    window.addEventListener('beforeinstallprompt', onBeforeInstallPrompt)
+    return () => window.removeEventListener('beforeinstallprompt', onBeforeInstallPrompt)
+  }, [])
+
+  if (dismissed || !mode) return null
+
+  const dismiss = () => {
+    setDismissed(true)
+    try {
+      localStorage.setItem(DISMISSED_KEY, 'true')
+    } catch {
+      // Ignore unavailable storage.
+    }
+  }
+
+  const install = async () => {
+    if (!promptEvent) return
+    await promptEvent.prompt()
+    const choice = await promptEvent.userChoice
+    if (choice.outcome === 'accepted') dismiss()
+    setPromptEvent(null)
+  }
+
+  const safariMobile =
+    /iPhone|iPad|iPod/.test(navigator.userAgent) ||
+    (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1)
+
+  return (
+    <aside
+      role="status"
+      className="fixed inset-x-4 bottom-4 z-40 mx-auto flex max-w-lg items-start gap-3 rounded-xl border border-border bg-elevated p-4 text-foreground shadow-[0_8px_24px_var(--shadow-primary)]"
+    >
+      <Download className="mt-0.5 size-4 shrink-0 text-accent" />
+      <div className="min-w-0 flex-1">
+        <p className="text-ui-sm font-medium">Install Open Run</p>
+        {mode === 'chrome' ? (
+          <p className="mt-1 text-ui-sm text-tier-tertiary">
+            {promptEvent
+              ? 'Install the app for quick access from your desktop or home screen.'
+              : 'Use Chrome’s install icon in the address bar or menu to add Open Run.'}
+          </p>
+        ) : (
+          <p className="mt-1 text-ui-sm text-tier-tertiary">
+            {safariMobile
+              ? 'Tap Share, then Add to Home Screen to install Open Run.'
+              : 'Choose File, then Add to Dock in Safari to install Open Run.'}
+          </p>
+        )}
+        {mode === 'chrome' && promptEvent ? (
+          <button
+            type="button"
+            onClick={() => void install()}
+            className="mt-3 rounded-md bg-accent px-3 py-1.5 text-ui-sm font-medium text-action-label hover:opacity-90"
+          >
+            Install app
+          </button>
+        ) : null}
+      </div>
+      <button
+        type="button"
+        aria-label="Dismiss install banner"
+        onClick={dismiss}
+        className="shrink-0 rounded-md p-1 text-tier-quaternary hover:bg-hover hover:text-foreground"
+      >
+        <X className="size-4" />
+      </button>
+    </aside>
+  )
+}

--- a/src/components/NewRunSurface.tsx
+++ b/src/components/NewRunSurface.tsx
@@ -6,11 +6,18 @@
  * copied into both routes.
  */
 import { AddProjectModal } from './AddProjectModal'
+import { useLocation, useNavigate } from '@tanstack/react-router'
+import { useQueryClient } from '@tanstack/react-query'
 import { Composer } from './chat/Composer'
 import { WorkingIndicator } from './chat/WorkingIndicator'
 import { RuntimePicker } from './ComposerControls'
 import { WorkspaceBreadcrumb } from './workspace/WorkspaceBreadcrumb'
 import type { NewRunDraft } from '../hooks/useNewRunDraft'
+import {
+  markRunReadOptimistically,
+  prefetchConversation,
+  useConversationNavigationRuns,
+} from '../lib/queries'
 
 export function NewRunBreadcrumb({
   draft,
@@ -41,6 +48,33 @@ export function NewRunComposer({
   /** Overrides the docked width/padding — the start page renders it inline. */
   className?: string
 }) {
+  const navigate = useNavigate()
+  const queryClient = useQueryClient()
+  const openedFromHome = useLocation({ select: (location) => location.pathname === '/' })
+  const { data: conversationRuns = [] } = useConversationNavigationRuns()
+
+  const openConversation = (runId: string) => {
+    const navigation = navigate({
+      to: '/runs/$runId',
+      params: { runId },
+      search: openedFromHome
+        ? {
+            from: 'home',
+            projectId: draft.projectId,
+            workspaceId: draft.workspaceId,
+            runtimeId: draft.runtimeId,
+            model: draft.model,
+            effort: draft.effort,
+          }
+        : {},
+    })
+
+    // The run detail marks itself read once it mounts. Do the visual half now
+    // so selecting a conversation never flashes a misleading unread dot.
+    void markRunReadOptimistically(queryClient, runId).catch(() => {})
+    return navigation
+  }
+
   return (
     <Composer
       {...(className ? { className } : {})}
@@ -61,16 +95,20 @@ export function NewRunComposer({
             align="start"
             sessions={{
               workspaceId: draft.workspaceId,
-              allWorkspaces: draft.allNativeSessions,
-              groups:
-                draft.workspaceId || draft.allNativeSessions
-                  ? (draft.nativeQuery.data?.groups ?? [])
-                  : [],
+              groups: draft.workspaceId ? (draft.nativeQuery.data?.groups ?? []) : [],
               resumeSessionId: draft.resumeSessionId,
               resumeSessionLabel: draft.resumeSessionLabel,
               onOpen: () => draft.nativeQuery.refetch(),
               onSelectNew: draft.clearResume,
               onSelect: draft.pickNativeSession,
+            }}
+            conversations={{
+              runs: conversationRuns.filter((run) => run.projectId === draft.projectId),
+              currentRunId: '',
+              workspaceId: draft.workspaceId,
+              projectId: draft.projectId,
+              onIntent: (runId) => void prefetchConversation(queryClient, runId),
+              onSelect: openConversation,
             }}
             onChange={draft.selectRuntime}
           />

--- a/src/components/chat/Composer.tsx
+++ b/src/components/chat/Composer.tsx
@@ -2,7 +2,6 @@
  * Chat / new-run prompt box: slash commands, plugin mentions, attachments, send.
  */
 import { useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
-import { Square } from 'lucide-react'
 import { ComposerModelControls } from '../ComposerControls'
 import { PluginMentionMenu } from '../PluginMentionMenu'
 import { SlashCommandMenu } from '../SlashCommandMenu'
@@ -89,6 +88,7 @@ export function Composer({
    * usually something they fix and then retry with the same words.
    */
   onSend: (text: string) => unknown
+  /** Cancel the active run with Escape while composing. */
   onStop?: () => void
   className?: string
   /** Slash commands to offer, app commands included. */
@@ -303,6 +303,14 @@ export function Composer({
                 files.addFiles(images)
               }}
               onKeyDown={(e) => {
+                // The composer used to expose a separate stop button. Escape
+                // keeps that interruption close to where the user is typing,
+                // including when a slash-command or plugin menu is open.
+                if (e.key === 'Escape' && running && onStop) {
+                  e.preventDefault()
+                  onStop()
+                  return
+                }
                 if (pluginMenuOpen && pluginMatches.length > 0) {
                   if (e.key === 'ArrowDown') {
                     e.preventDefault()
@@ -452,17 +460,6 @@ export function Composer({
                   disabled={!canAttach || files.full}
                   onFiles={(picked) => files.addFiles(picked)}
                 />
-              ) : null}
-              {running && onStop ? (
-                <button
-                  type="button"
-                  onClick={onStop}
-                  aria-label="Stop"
-                  title="Stop"
-                  className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-warn/90 text-white transition-colors hover:bg-warn focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/70"
-                >
-                  <Square className="size-3.5 fill-current" />
-                </button>
               ) : null}
             </div>
           </div>

--- a/src/components/workspace/NavigationPicker.tsx
+++ b/src/components/workspace/NavigationPicker.tsx
@@ -119,9 +119,13 @@ export function NavigationItem({
   disabled,
   unread,
   reserveTrailing,
+  showActiveIndicator = true,
   meta,
   onSelect,
   onClick,
+  onPointerDown,
+  onPointerEnter,
+  onFocus,
 }: {
   label: string
   hint?: string
@@ -134,10 +138,15 @@ export function NavigationItem({
    * check itself, so the tick and a hover action can share one fixed position.
    */
   reserveTrailing?: boolean
+  showActiveIndicator?: boolean
   /** Right-aligned secondary text, before the unread dot and the check. */
   meta?: ReactNode
   onSelect: () => void
   onClick?: (event: ReactMouseEvent<HTMLButtonElement>) => void
+  /** Start latency-sensitive work on press, before the click is dispatched. */
+  onPointerDown?: () => void
+  onPointerEnter?: () => void
+  onFocus?: () => void
 }) {
   return (
     <button
@@ -146,6 +155,9 @@ export function NavigationItem({
       disabled={disabled}
       title={hint ?? label}
       onClick={onClick ?? onSelect}
+      onPointerDown={onPointerDown}
+      onPointerEnter={onPointerEnter}
+      onFocus={onFocus}
       className={`flex w-full items-center gap-2 rounded-lg px-2.5 py-1.5 text-left transition-colors disabled:cursor-not-allowed disabled:opacity-50 ${reserveTrailing ? 'pr-8' : ''} ${
         active ? 'bg-secondary text-foreground' : 'text-foreground/85 hover:bg-secondary/70'
       }`}
@@ -167,7 +179,7 @@ export function NavigationItem({
           className="size-1.5 shrink-0 rounded-full bg-accent"
         />
       ) : null}
-      {active && !reserveTrailing ? (
+      {active && !reserveTrailing && showActiveIndicator ? (
         <Check className="size-3.5 shrink-0" aria-hidden="true" />
       ) : null}
     </button>

--- a/src/contract/generated/client.ts
+++ b/src/contract/generated/client.ts
@@ -36,6 +36,7 @@ export const ROUTES: Record<string, RouteInfo> = {
   'files.writeWorkspace': { method: 'POST', path: '/api/v1/files/write-workspace' },
   'files.restoreWorkspace': { method: 'POST', path: '/api/v1/files/restore-workspace' },
   'files.saveAttachment': { method: 'POST', path: '/api/v1/files/save-attachment' },
+  'code.highlight': { method: 'POST', path: '/api/v1/code/highlight' },
   'git.getFileDiff': { method: 'GET', path: '/api/v1/git/get-file-diff' },
   'git.commitChanges': { method: 'POST', path: '/api/v1/git/commit-changes' },
   'git.pushChanges': { method: 'POST', path: '/api/v1/git/push-changes' },
@@ -317,6 +318,11 @@ export class OpenRunClient {
     data: string
   }): Promise<unknown> {
     return this.call('files.saveAttachment', input)
+  }
+
+  /** Tokenize a snippet with the app's own highlighter; answers class names, not colours. */
+  highlightCodeBlock(input: { code: string; language?: string; path?: string }): Promise<unknown> {
+    return this.call('code.highlight', input)
   }
 
   getFileDiff(input: { runId: string; path: string; whole?: boolean }): Promise<unknown> {

--- a/src/contract/generated/openapi.json
+++ b/src/contract/generated/openapi.json
@@ -967,6 +967,63 @@
         }
       }
     },
+    "/api/v1/code/highlight": {
+      "post": {
+        "operationId": "code.highlight",
+        "summary": "Tokenize a snippet with the app's own highlighter; answers class names, not colours.",
+        "tags": [
+          "code"
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/Refused"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          }
+        },
+        "x-openrun-clients": [
+          "desktop"
+        ],
+        "x-openrun-capability": "code.highlight",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "code": {
+                    "type": "string"
+                  },
+                  "language": {
+                    "type": "string"
+                  },
+                  "path": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "code"
+                ],
+                "additionalProperties": true
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/git/get-file-diff": {
       "get": {
         "operationId": "git.getFileDiff",

--- a/src/contract/operations.ts
+++ b/src/contract/operations.ts
@@ -291,8 +291,7 @@ export const OPERATIONS = [
     capability: 'code.highlight',
     clients: ['desktop'],
     inputType: '{ code: string; language?: string; path?: string }',
-    summary:
-      'Tokenize a snippet with the app\'s own highlighter; answers class names, not colours.',
+    summary: "Tokenize a snippet with the app's own highlighter; answers class names, not colours.",
   },
 
   // --- git -----------------------------------------------------------------

--- a/src/contract/operations.ts
+++ b/src/contract/operations.ts
@@ -279,6 +279,22 @@ export const OPERATIONS = [
     summary: 'Upload a composer image; `data` is raw base64 without the data-URL prefix.',
   },
 
+  // --- code ----------------------------------------------------------------
+  {
+    id: 'code.highlight',
+    fn: 'highlightCodeBlock',
+    method: 'POST',
+    path: '/api/v1/code/highlight',
+    core: 'highlightCodeBlock',
+    args: 'payload',
+    input: { code: 'string', language: 'string?', path: 'string?' },
+    capability: 'code.highlight',
+    clients: ['desktop'],
+    inputType: '{ code: string; language?: string; path?: string }',
+    summary:
+      'Tokenize a snippet with the app\'s own highlighter; answers class names, not colours.',
+  },
+
   // --- git -----------------------------------------------------------------
   {
     id: 'git.getFileDiff',

--- a/src/fns/index.ts
+++ b/src/fns/index.ts
@@ -139,6 +139,17 @@ export const listHostedConnections = createServerFn({ method: 'GET' }).handler(
   async () => run('cloud.listHostedConnections') as Promise<CoreResult<'listHostedConnections'>>,
 )
 
+// --- code --------------------------------------------------------------------
+
+/** Tokenize a snippet with the app's own highlighter; answers class names, not colours. */
+export const highlightCodeBlock = createServerFn({ method: 'POST' })
+  .validator((d: { code: string; language?: string; path?: string }) =>
+    shape(d, { code: 'string', language: 'string?', path: 'string?' }),
+  )
+  .handler(
+    async ({ data }) => run('code.highlight', data) as Promise<CoreResult<'highlightCodeBlock'>>,
+  )
+
 // --- dashboard ---------------------------------------------------------------
 
 export const dashboard = createServerFn({ method: 'GET' }).handler(

--- a/src/hooks/useNewRunDraft.ts
+++ b/src/hooks/useNewRunDraft.ts
@@ -7,7 +7,7 @@
  * that read it stay presentational.
  */
 import { useEffect, useMemo, useState } from 'react'
-import { useNavigate } from '@tanstack/react-router'
+import { useLocation, useNavigate } from '@tanstack/react-router'
 import {
   defaultEffort,
   defaultModel,
@@ -48,11 +48,9 @@ export type NewRunSeed = {
 
 export type NewRunDraft = ReturnType<typeof useNewRunDraft>
 
-export function useNewRunDraft(
-  seed: NewRunSeed = {},
-  options: { allNativeSessions?: boolean } = {},
-) {
+export function useNewRunDraft(seed: NewRunSeed = {}) {
   const navigate = useNavigate()
+  const openedFromHome = useLocation({ select: (location) => location.pathname === '/' })
   const { prefs, remember } = usePickerPrefs()
   const { data: projects } = useProjects()
   const { data: runtimes } = useRuntimes()
@@ -162,6 +160,18 @@ export function useNewRunDraft(
   const selectProject = (id: string) => {
     setProjectId(id)
     setWorkspaceId('')
+    const search = { projectId: id, runtimeId, model, effort }
+    void (openedFromHome
+      ? navigate({ to: '/', search, replace: true })
+      : navigate({ to: '/runs/new', search, replace: true }))
+  }
+
+  const selectBranch = (id: string) => {
+    setWorkspaceId(id)
+    const search = { projectId, workspaceId: id, runtimeId, model, effort }
+    void (openedFromHome
+      ? navigate({ to: '/', search, replace: true })
+      : navigate({ to: '/runs/new', search, replace: true }))
   }
 
   const clearResume = () => {
@@ -208,7 +218,12 @@ export function useNewRunDraft(
         runtimeMode: DEFAULT_RUNTIME_MODE,
       },
       {
-        onSuccess: ({ runId }) => navigate({ to: '/runs/$runId', params: { runId } }),
+        onSuccess: ({ runId }) =>
+          navigate({
+            to: '/runs/$runId',
+            params: { runId },
+            search: openedFromHome ? { from: 'home' } : {},
+          }),
         onError: (err) => setError(err instanceof Error ? err.message : String(err)),
       },
     )
@@ -248,7 +263,11 @@ export function useNewRunDraft(
         resumeSessionId,
         resumeSessionLabel,
       })
-      await navigate({ to: '/runs/$runId', params: { runId } })
+      await navigate({
+        to: '/runs/$runId',
+        params: { runId },
+        search: openedFromHome ? { from: 'home' } : {},
+      })
     } catch (err) {
       setSent(null)
       setError(err instanceof Error ? err.message : String(err))
@@ -274,7 +293,6 @@ export function useNewRunDraft(
     pluginListing,
     uploadAttachment,
     nativeQuery,
-    allNativeSessions: Boolean(options.allNativeSessions),
     resumeSessionId,
     resumeSessionLabel,
     blockedReason,
@@ -287,7 +305,7 @@ export function useNewRunDraft(
     addingProject,
     setAddingProject,
     selectProject,
-    selectBranch: setWorkspaceId,
+    selectBranch,
     selectRuntime,
     clearResume,
     pickNativeSession,

--- a/src/lib/editorTheme.ts
+++ b/src/lib/editorTheme.ts
@@ -4,20 +4,11 @@
  * Colors are pulled from the same `--syntax-*` custom properties the rest of
  * the app uses, so the editor matches the workspace chrome exactly.
  */
-import { HighlightStyle, type LanguageSupport, syntaxHighlighting } from '@codemirror/language'
+import { HighlightStyle, syntaxHighlighting } from '@codemirror/language'
 import { EditorView } from '@codemirror/view'
 import { tags as t } from '@lezer/highlight'
 import type { Extension } from '@codemirror/state'
-
-import { css } from '@codemirror/lang-css'
-import { html } from '@codemirror/lang-html'
-import { javascript } from '@codemirror/lang-javascript'
-import { json } from '@codemirror/lang-json'
-import { markdown } from '@codemirror/lang-markdown'
-import { python } from '@codemirror/lang-python'
-import { rust } from '@codemirror/lang-rust'
-import { sql } from '@codemirror/lang-sql'
-import { yaml } from '@codemirror/lang-yaml'
+import { languageSupportForPath } from './languageSupport.ts'
 
 /** Editor chrome — transparent so the panel background shows through. */
 export const workspaceEditorTheme = EditorView.theme(
@@ -89,52 +80,6 @@ const workspaceHighlight = HighlightStyle.define([
 ])
 
 export const workspaceSyntaxHighlighting = syntaxHighlighting(workspaceHighlight)
-
-/** Pick a language support from the file extension. */
-export function languageSupportForPath(path: string): LanguageSupport | null {
-  const ext = path.slice(path.lastIndexOf('.') + 1).toLowerCase()
-  switch (ext) {
-    case 'ts':
-    case 'mts':
-    case 'cts':
-      return javascript({ typescript: true })
-    case 'tsx':
-      return javascript({ typescript: true, jsx: true })
-    case 'js':
-    case 'mjs':
-    case 'cjs':
-      return javascript()
-    case 'jsx':
-      return javascript({ jsx: true })
-    case 'json':
-    case 'jsonc':
-      return json()
-    case 'css':
-    case 'scss':
-    case 'less':
-      return css()
-    case 'html':
-    case 'htm':
-    case 'vue':
-    case 'svelte':
-      return html()
-    case 'md':
-    case 'mdx':
-    case 'markdown':
-      return markdown()
-    case 'py':
-      return python()
-    case 'rs':
-      return rust()
-    case 'sql':
-      return sql()
-    case 'yaml':
-    case 'yml':
-      return yaml()
-    default:
-      return null
-  }
-}
 
 /** Pick a language extension from the file extension. */
 export function languageForPath(path: string): Extension[] {

--- a/src/lib/highlight.ts
+++ b/src/lib/highlight.ts
@@ -1,6 +1,7 @@
 import { highlightCode, tagHighlighter, tags as t } from '@lezer/highlight'
 import type { DiffHunk, DiffLine } from './diff'
-import { languageSupportForPath } from './editorTheme'
+import { languageSupportForPath } from './languageSupport.ts'
+import { syntheticPathForLanguage } from './codeLanguage.ts'
 
 export type HighlightToken = {
   text: string
@@ -79,4 +80,40 @@ export function highlightDiffLines(
   })
 
   return map
+}
+
+/**
+ * Caps borrowed from t3code's mobile highlighter: past these sizes tokenizing
+ * costs more than the colour is worth, and a pathological line can pin the
+ * parser. Over either cap the snippet comes back plain.
+ */
+export const MAX_HIGHLIGHT_CHARS = 200_000
+export const MAX_HIGHLIGHT_LINE_CHARS = 1_000
+
+export type HighlightedSnippet = {
+  lines: HighlightToken[][]
+  /** False when the caps or a missing grammar left the tokens plain. */
+  highlighted: boolean
+}
+
+/**
+ * Tokenize a fenced snippet for a client that has no highlighter of its own.
+ *
+ * `path` wins when both are given — a fence title names the real file, which
+ * resolves more grammars than a bare language id does.
+ */
+export function highlightSnippet(input: {
+  code: string
+  language?: string
+  path?: string
+}): HighlightedSnippet {
+  const code = input.code
+  const path = input.path || syntheticPathForLanguage(input.language ?? '')
+  const tooLong =
+    code.length > MAX_HIGHLIGHT_CHARS ||
+    code.split('\n').some((line) => line.length > MAX_HIGHLIGHT_LINE_CHARS)
+  if (tooLong || !languageSupportForPath(path)) {
+    return { lines: plainLines(code), highlighted: false }
+  }
+  return { lines: highlightLines(code, path), highlighted: true }
 }

--- a/src/lib/languageSupport.ts
+++ b/src/lib/languageSupport.ts
@@ -1,0 +1,64 @@
+/**
+ * File extension → CodeMirror language support.
+ *
+ * Split out of `editorTheme.ts` so the highlighter can be reached without
+ * pulling in `EditorView` and the editor chrome: `server/core.ts` tokenizes
+ * snippets for clients that have no highlighter of their own.
+ */
+import type { LanguageSupport } from '@codemirror/language'
+
+import { css } from '@codemirror/lang-css'
+import { html } from '@codemirror/lang-html'
+import { javascript } from '@codemirror/lang-javascript'
+import { json } from '@codemirror/lang-json'
+import { markdown } from '@codemirror/lang-markdown'
+import { python } from '@codemirror/lang-python'
+import { rust } from '@codemirror/lang-rust'
+import { sql } from '@codemirror/lang-sql'
+import { yaml } from '@codemirror/lang-yaml'
+
+/** Pick a language support from the file extension. */
+export function languageSupportForPath(path: string): LanguageSupport | null {
+  const ext = path.slice(path.lastIndexOf('.') + 1).toLowerCase()
+  switch (ext) {
+    case 'ts':
+    case 'mts':
+    case 'cts':
+      return javascript({ typescript: true })
+    case 'tsx':
+      return javascript({ typescript: true, jsx: true })
+    case 'js':
+    case 'mjs':
+    case 'cjs':
+      return javascript()
+    case 'jsx':
+      return javascript({ jsx: true })
+    case 'json':
+    case 'jsonc':
+      return json()
+    case 'css':
+    case 'scss':
+    case 'less':
+      return css()
+    case 'html':
+    case 'htm':
+    case 'vue':
+    case 'svelte':
+      return html()
+    case 'md':
+    case 'mdx':
+    case 'markdown':
+      return markdown()
+    case 'py':
+      return python()
+    case 'rs':
+      return rust()
+    case 'sql':
+      return sql()
+    case 'yaml':
+    case 'yml':
+      return yaml()
+    default:
+      return null
+  }
+}

--- a/src/lib/pickRuntime.test.ts
+++ b/src/lib/pickRuntime.test.ts
@@ -70,6 +70,13 @@ describe('visibleRuntimes', () => {
     )
   })
 
+  it('always keeps Codex visible, even with a stale hidden preference', () => {
+    assert.deepEqual(
+      visibleRuntimes(catalog, ['codex']).map((r) => r.id),
+      ['claude', 'codex', 'grok', 'gemini'],
+    )
+  })
+
   it('falls back to the full catalog rather than an empty menu', () => {
     const all = catalog.map((r) => r.id)
     assert.deepEqual(
@@ -95,6 +102,13 @@ describe('hiddenRuntimesIn', () => {
     assert.deepEqual(hiddenRuntimesIn(catalog, undefined), [])
   })
 
+  it('does not list Codex as hidden', () => {
+    assert.deepEqual(
+      hiddenRuntimesIn(catalog, ['codex']).map((r) => r.id),
+      [],
+    )
+  })
+
   it('does not also list a hidden runtime kept as the selection', () => {
     assert.deepEqual(
       hiddenRuntimesIn(catalog, ['grok', 'gemini'], 'grok').map((r) => r.id),
@@ -108,5 +122,10 @@ describe('toggleHiddenRuntime', () => {
     assert.deepEqual(toggleHiddenRuntime(undefined, 'grok'), ['grok'])
     assert.deepEqual(toggleHiddenRuntime(['grok'], 'gemini'), ['grok', 'gemini'])
     assert.deepEqual(toggleHiddenRuntime(['grok', 'gemini'], 'grok'), ['gemini'])
+  })
+
+  it('removes a stale Codex hidden preference instead of saving it', () => {
+    assert.deepEqual(toggleHiddenRuntime(['codex', 'grok'], 'codex'), ['grok'])
+    assert.deepEqual(toggleHiddenRuntime(['grok'], 'codex'), ['grok'])
   })
 })

--- a/src/lib/pickRuntime.ts
+++ b/src/lib/pickRuntime.ts
@@ -11,6 +11,11 @@ export type RuntimePickCandidate = {
   installed?: boolean
 }
 
+/** Codex stays selectable even when a stale local preference says otherwise. */
+export function isAlwaysVisibleRuntime(id: string): boolean {
+  return id === 'codex'
+}
+
 /**
  * Apply the user's hidden-runtime list to a catalog.
  *
@@ -26,7 +31,10 @@ export function visibleRuntimes<T extends { id: string }>(
 ): T[] {
   if (!hidden || hidden.length === 0) return [...runtimes]
   const hide = new Set(hidden)
-  const kept = runtimes.filter((r) => !hide.has(r.id) || r.id === keepId)
+  if (runtimes.every((r) => hide.has(r.id) && r.id !== keepId)) return [...runtimes]
+  const kept = runtimes.filter(
+    (r) => isAlwaysVisibleRuntime(r.id) || !hide.has(r.id) || r.id === keepId,
+  )
   return kept.length > 0 ? kept : [...runtimes]
 }
 
@@ -46,6 +54,7 @@ export function hiddenRuntimesIn<T extends { id: string }>(
 /** Flip one runtime between hidden and shown, returning the next hidden list. */
 export function toggleHiddenRuntime(hidden: readonly string[] | undefined, id: string): string[] {
   const list = hidden ?? []
+  if (isAlwaysVisibleRuntime(id)) return list.filter((s) => s !== id)
   return list.includes(id) ? list.filter((s) => s !== id) : [...list, id]
 }
 

--- a/src/lib/queries.ts
+++ b/src/lib/queries.ts
@@ -393,6 +393,18 @@ export function useMarkRunRead() {
   })
 }
 
+/** Clear navigation dots immediately and persist the read before route mount. */
+export function markRunReadOptimistically(qc: QueryClient, id: string) {
+  qc.setQueryData<Array<{ id: string; unread?: boolean }>>(
+    ['runs', 'conversation-navigation'],
+    (runs) => runs?.map((run) => (run.id === id ? { ...run, unread: false } : run)),
+  )
+  if (isDemoDetailRun(id)) return Promise.resolve()
+  return fns.markRunRead({ data: { id } }).then(() => {
+    void qc.invalidateQueries({ queryKey: ['runs', 'conversation-navigation'] })
+  })
+}
+
 export function conversationQueryOptions(runId: string) {
   const demo = isDemoMode() && isDemoDetailRun(runId)
   return {

--- a/src/lib/threadLens.test.ts
+++ b/src/lib/threadLens.test.ts
@@ -26,6 +26,18 @@ const run = (
 })
 
 describe('groupThreadLensRuns', () => {
+  it('keeps one selectable row when the navigation result repeats a run', () => {
+    const duplicated = run('one', 'ws-a', 'project-a', 2)
+    const groups = groupThreadLensRuns(
+      [duplicated, { ...duplicated }, { ...duplicated }, { ...duplicated }],
+      { workspaceId: 'ws-a', projectId: 'project-a' },
+    )
+    assert.deepEqual(
+      groups[0]?.runs.map((item) => item.id),
+      ['one'],
+    )
+  })
+
   it('lists only the current worktree until you search', () => {
     const groups = groupThreadLensRuns(
       [

--- a/src/lib/threadLens.ts
+++ b/src/lib/threadLens.ts
@@ -18,6 +18,20 @@ export type ThreadLensGroup = {
   runs: ThreadLensRun[]
 }
 
+/**
+ * A navigation result is an index, not an event feed: one run must result in
+ * one selectable conversation. Keep the newest copy in case a cache update
+ * briefly joins an older result with a newer one.
+ */
+export function uniqueThreadLensRuns(runs: ThreadLensRun[]): ThreadLensRun[] {
+  const byId = new Map<string, ThreadLensRun>()
+  for (const run of runs) {
+    const existing = byId.get(run.id)
+    if (!existing || run.startedAt > existing.startedAt) byId.set(run.id, run)
+  }
+  return [...byId.values()]
+}
+
 export function threadNavigationIndex(runs: ThreadLensRun[]): {
   unreadWorkspaceIds: Set<string>
   latestRunIdByWorkspace: Map<string, string>
@@ -26,7 +40,7 @@ export function threadNavigationIndex(runs: ThreadLensRun[]): {
   const unreadWorkspaceIds = new Set<string>()
   const latestRunIdByWorkspace = new Map<string, string>()
   const latestRunIdByProject = new Map<string, string>()
-  for (const run of [...runs].sort((a, b) => b.startedAt - a.startedAt)) {
+  for (const run of uniqueThreadLensRuns(runs).sort((a, b) => b.startedAt - a.startedAt)) {
     if (run.unread && run.workspaceId) unreadWorkspaceIds.add(run.workspaceId)
     if (run.workspaceId && !latestRunIdByWorkspace.has(run.workspaceId)) {
       latestRunIdByWorkspace.set(run.workspaceId, run.id)
@@ -44,7 +58,7 @@ export function adjacentThreadId(
   runId: string,
   direction: -1 | 1,
 ): string | null {
-  const threads = runs
+  const threads = uniqueThreadLensRuns(runs)
     .filter((run) => run.workspaceId === workspaceId)
     .sort((a, b) => b.startedAt - a.startedAt)
   if (threads.length < 2) return null
@@ -63,7 +77,8 @@ export function groupThreadLensRuns(
   query = '',
 ): ThreadLensGroup[] {
   const needle = query.trim().toLocaleLowerCase()
-  const scoped = needle ? runs : runs.filter((run) => run.workspaceId === current.workspaceId)
+  const unique = uniqueThreadLensRuns(runs)
+  const scoped = needle ? unique : unique.filter((run) => run.workspaceId === current.workspaceId)
   const matching = needle
     ? scoped.filter((run) =>
         [run.chatTitle, run.runtimeLabel, run.workspaceBranch, run.projectName].some((value) =>

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -2,12 +2,35 @@ import { createRouter as createTanStackRouter } from '@tanstack/react-router'
 import { routeTree } from './routeTree.gen'
 import { getQueryClient } from './lib/queryClient'
 
+function RoutePendingSkeleton() {
+  return (
+    <div className="flex h-[calc(100vh-var(--header-h,0px))] min-h-0 flex-col bg-background">
+      <div className="flex h-[var(--workspace-topbar-height,44px)] shrink-0 items-center gap-2 border-b border-border px-3">
+        <div className="size-4 animate-pulse rounded bg-muted-foreground/10" />
+        <div className="h-3 w-28 animate-pulse rounded bg-muted-foreground/10" />
+        <div className="h-3 w-20 animate-pulse rounded bg-muted-foreground/10" />
+      </div>
+      <div className="mx-auto w-full max-w-3xl flex-1 space-y-5 px-5 pt-5">
+        <div className="ml-auto h-14 w-[55%] animate-pulse rounded-[10px] bg-secondary" />
+        <div className="space-y-2">
+          <div className="h-3 w-24 animate-pulse rounded bg-muted-foreground/10" />
+          <div className="h-3 w-full max-w-md animate-pulse rounded bg-muted-foreground/10" />
+          <div className="h-3 w-[85%] max-w-sm animate-pulse rounded bg-muted-foreground/10" />
+        </div>
+      </div>
+    </div>
+  )
+}
+
 export function getRouter() {
   const router = createTanStackRouter({
     routeTree,
     scrollRestoration: true,
     defaultPreload: 'intent',
     defaultPreloadStaleTime: 0,
+    defaultPendingMs: 0,
+    defaultPendingMinMs: 0,
+    defaultPendingComponent: RoutePendingSkeleton,
     context: {
       queryClient: getQueryClient(),
     },

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -32,6 +32,7 @@ import {
 } from '../components/AppChrome'
 import { ChatThemeProvider } from '../components/chat/ChatThemeProvider'
 import { DevLiveStatus } from '../components/DevLiveStatus'
+import { InstallBanner } from '../components/InstallBanner'
 import { Toaster } from '../components/toast'
 import { CHAT_THEME_BOOT_SCRIPT } from '../lib/chatTheme'
 import { TERMINAL_PALETTE_BOOT_SCRIPT } from '../lib/terminalPalette'
@@ -45,6 +46,7 @@ export const Route = createRootRouteWithContext<{ queryClient: QueryClient }>()(
     meta: [
       { charSet: 'utf-8' },
       { name: 'viewport', content: 'width=device-width, initial-scale=1' },
+      { name: 'theme-color', content: '#141414' },
       { title: 'Open Run' },
     ],
     links: [
@@ -286,6 +288,7 @@ function RootDocument({ children }: { children: ReactNode }) {
             <ActivityLiveProvider>
               {children}
               <Toaster />
+              <InstallBanner />
               <DevLiveStatus />
             </ActivityLiveProvider>
           </ChatThemeProvider>

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -31,7 +31,7 @@ export const Route = createFileRoute('/')({
 })
 
 function StartPage() {
-  const draft = useNewRunDraft(Route.useSearch(), { allNativeSessions: true })
+  const draft = useNewRunDraft(Route.useSearch())
   const noProjects = draft.projects?.length === 0
 
   return (

--- a/src/routes/runs.$runId.tsx
+++ b/src/routes/runs.$runId.tsx
@@ -11,7 +11,6 @@ import { useQueryClient } from '@tanstack/react-query'
 import * as fns from '../fns'
 import { Chat } from '../components/Chat'
 import { ChatDebugMenuItem } from '../components/chat/ChatDebugToggle'
-import { ThreadStack } from '../components/chat/ThreadStack'
 import { TerminalPaletteMenuItems } from '../components/chat/TerminalPalettePicker'
 import { useChatTheme } from '../components/chat/ChatThemeProvider'
 import { DiffPanel } from '../components/DiffPanel'
@@ -42,7 +41,6 @@ import {
 import { defaultEffort, defaultModel, modelsForRuntime } from '../lib/models'
 import type { RuntimeMode } from '../lib/runtimeMode'
 import { isWorkspaceReady } from '../lib/workspaceReady'
-import { runListTitle } from '../lib/runPreview'
 import {
   NO_RUN_COMMITS,
   shortSha,
@@ -52,7 +50,24 @@ import {
 import { isDemoDetailRun, isDemoMode } from '../lib/demoData.ts'
 import { useRunLive } from '../lib/useRunLive'
 
+type RunDetailSearch = {
+  from?: 'home'
+  projectId?: string
+  workspaceId?: string
+  runtimeId?: string
+  model?: string
+  effort?: string
+}
+
 export const Route = createFileRoute('/runs/$runId')({
+  validateSearch: (search: Record<string, unknown>): RunDetailSearch => ({
+    ...(search.from === 'home' ? { from: 'home' as const } : {}),
+    ...(typeof search.projectId === 'string' ? { projectId: search.projectId } : {}),
+    ...(typeof search.workspaceId === 'string' ? { workspaceId: search.workspaceId } : {}),
+    ...(typeof search.runtimeId === 'string' ? { runtimeId: search.runtimeId } : {}),
+    ...(typeof search.model === 'string' ? { model: search.model } : {}),
+    ...(typeof search.effort === 'string' ? { effort: search.effort } : {}),
+  }),
   loader: ({ context, params }) => {
     void prefetchConversation(context.queryClient, params.runId)
   },
@@ -112,6 +127,14 @@ function loadLayout(runId: string): LayoutState {
 
 function RunDetail() {
   const { runId } = Route.useParams()
+  const {
+    from,
+    projectId: homeProjectId,
+    workspaceId,
+    runtimeId,
+    model,
+    effort,
+  } = Route.useSearch()
   const { streamHealthy } = useRunLive(runId)
   const { data, isLoading } = useConversation(runId, { streamHealthy })
   const { data: runtimes } = useRuntimes()
@@ -303,6 +326,19 @@ function RunDetail() {
     })
   }, [data, qc])
 
+  // Escape is the keyboard equivalent of cancelling a working run. The
+  // composer handles it first, so an open completion menu cannot obscure it.
+  useEffect(() => {
+    if (!runWorking) return
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== 'Escape' || event.defaultPrevented || event.repeat) return
+      event.preventDefault()
+      onStop()
+    }
+    document.addEventListener('keydown', handleKeyDown)
+    return () => document.removeEventListener('keydown', handleKeyDown)
+  }, [onStop, runWorking])
+
   // Keep the workspace chrome mounted while conversation loads — only the
   // transcript waits. "Not found" waits until the first fetch settles.
   if (!isLoading && !data) {
@@ -421,9 +457,20 @@ function RunDetail() {
             <header className="flex h-[var(--workspace-topbar-height,44px)] shrink-0 items-center gap-1.5 border-b border-border px-3">
               {!sidebarOpen ? <SidebarToggle /> : null}
               <Link
-                to="/runs"
+                to={from === 'home' ? '/' : '/runs'}
+                search={
+                  from === 'home'
+                    ? {
+                        projectId: homeProjectId,
+                        workspaceId,
+                        runtimeId,
+                        model,
+                        effort,
+                      }
+                    : {}
+                }
                 className="flex shrink-0 items-center rounded-md p-1 text-muted-foreground transition-colors hover:bg-[var(--bg-luminous-quaternary)] hover:text-foreground"
-                title="Back to run history"
+                title={from === 'home' ? 'Back to home' : 'Back to run history'}
               >
                 <ArrowLeft className="h-4 w-4" />
               </Link>
@@ -568,6 +615,7 @@ function RunDetail() {
                 checkResults={checkResults}
                 pullRequest={pullRequest ?? null}
                 repositoryUrl={project?.remoteUrl}
+                returnToHome={from === 'home'}
                 models={models}
                 runId={runId}
                 runtimeId={data?.runtime?.id ?? fallbackRuntime?.id}

--- a/src/server/core.ts
+++ b/src/server/core.ts
@@ -32,6 +32,7 @@ import {
   type TaskReadinessBlocker,
 } from '../lib/taskReadiness.ts'
 import { clampRepairAttempts, parseVerdict } from '../lib/verdict'
+import { highlightSnippet } from '../lib/highlight.ts'
 import { assertWorkspaceId, hasWorkspaceId } from '../lib/workspaceRef'
 import {
   requiresGhAuth,
@@ -3262,4 +3263,20 @@ export async function completeCloudLoginAndFinish(input: { code: string; state: 
   const session = await completeCloudLogin(input)
   await afterSignIn()
   return { email: session.email, userId: session.userId, next: session.next }
+}
+
+// ---------------------------------------------------------------------------
+// Syntax highlighting for clients without a highlighter of their own.
+// ---------------------------------------------------------------------------
+
+/**
+ * Tokenize a code block with the same lezer highlighter the web transcript and
+ * the git panel use, so a native client paints the identical colours instead
+ * of shipping a second grammar set that would drift from ours.
+ *
+ * Class names travel, not colours: the client maps `hl-keyword` onto its own
+ * theme token exactly as `styles.css` does.
+ */
+export function highlightCodeBlock(input: { code: string; language?: string; path?: string }) {
+  return highlightSnippet(input)
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -444,6 +444,10 @@ body {
   /* Assistant prose font — `inherit` keeps the app's sans stack. */
   --chat-prose-font-family: inherit;
 
+  /* Inline `code` inside prose. A token rather than a rule, so the native
+     clients can read the same value instead of recomputing the mix. */
+  --chat-inline-code: color-mix(in oklab, var(--syntax-string) 48%, var(--text-primary));
+
   /* The user's own message. */
   --chat-user-align: flex-end;
   --chat-user-width: 80%;
@@ -885,7 +889,7 @@ body {
   padding: 0;
   font-family: ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace;
   font-size: 0.9em;
-  color: color-mix(in oklab, var(--syntax-string) 48%, var(--text-primary));
+  color: var(--chat-inline-code);
 }
 
 .chat-markdown strong {


### PR DESCRIPTION
## Summary
- Syntax highlighting is served to native clients as `hl-*` class names via a new `code.highlight` operation, so an Apple client colours code without owning a grammar.
- The start page and composer carry the run draft further: runtime/model pickers, navigation picker and install banner follow the same draft state.

## Test plan
- [ ] Open a run at `/runs/:runId` and confirm code blocks and diff hunks still colour correctly in both chat themes
- [ ] Call `code.highlight` over `/api/v1` with a `.ts` snippet and confirm the response carries `hl-*` classes, never colours
- [ ] From the start page, pick a runtime and model, start a chat, and confirm the draft selection is the one the run uses
