### PR TITLE
refactor(tasks): inline readiness and drop cancel

### DIFF
--- a/changelog.d/automation-form-layout.md
+++ b/changelog.d/automation-form-layout.md
@@ -1,0 +1,6 @@
+- The automation form no longer shows a Cancel button at the top; use the
+  Automations breadcrumb to leave without saving.
+
+- Workspace readiness now sits on the same row as the verification toggle when
+  everything is saved, and the ready state is a compact icon instead of a full
+  label.

--- a/src/components/TaskForm.tsx
+++ b/src/components/TaskForm.tsx
@@ -896,14 +896,12 @@ function StepLabel({ n, children }: { n: number; children: ReactNode }) {
 export function TaskForm({
   initial,
   onSaved,
-  onCancel,
   readiness,
   workspaceChangeBlockedReason,
   demoPreview = false,
 }: {
   initial?: Partial<TaskFormValues>
   onSaved: (id: string) => void
-  onCancel: () => void
   readiness?: ReactNode
   workspaceChangeBlockedReason?: string | null
   /** Interactive, page-local preview that never persists an automation. */
@@ -1277,9 +1275,6 @@ export function TaskForm({
             autoFocus
           />
           <div className="flex shrink-0 items-center gap-2 pt-2">
-            <Button type="button" variant="ghost" onClick={onCancel}>
-              Cancel
-            </Button>
             <span className="inline-flex" title={saveBlockReason}>
               {/*
                 Every refusal in one place: `saveBlockReason` already folds in
@@ -1683,7 +1678,7 @@ export function TaskForm({
           </div>
         </section>
 
-        <section>
+        <section className="flex flex-wrap items-center justify-between gap-x-3 gap-y-2">
           <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
             <Button
               type="button"
@@ -1700,6 +1695,7 @@ export function TaskForm({
               </span>
             ) : null}
           </div>
+          {workspaceChanged ? null : readiness}
           {showVerificationSettings ? (
             <VerificationSection
               verifyEnabled={verifyEnabled}
@@ -1722,6 +1718,7 @@ export function TaskForm({
                 setDirty(true)
                 setRequireGhAuth(on)
               }}
+              className="w-full"
             />
           ) : null}
         </section>
@@ -1734,9 +1731,7 @@ export function TaskForm({
               Readiness will update from the new workspace immediately after saving.
             </p>
           </Card>
-        ) : (
-          readiness
-        )}
+        ) : null}
 
         {save.isError ? (
           <p className="rounded-lg border border-rose-500/20 bg-rose-500/5 px-3 py-2 text-sm text-rose-300">
@@ -1773,6 +1768,7 @@ function VerificationSection({
   onTimeoutMinutesChange,
   requireGhAuth,
   onRequireGhAuthChange,
+  className,
 }: {
   verifyEnabled: boolean
   onVerifyEnabledChange: (value: boolean) => void
@@ -1782,9 +1778,12 @@ function VerificationSection({
   onTimeoutMinutesChange: (value: number) => void
   requireGhAuth: boolean
   onRequireGhAuthChange: (value: boolean) => void
+  className?: string
 }) {
   return (
-    <div className="mt-2 space-y-3 rounded-xl border border-border bg-elevated px-3.5 py-3">
+    <div
+      className={`mt-2 space-y-3 rounded-xl border border-border bg-elevated px-3.5 py-3 ${className ?? ''}`}
+    >
       <label className="flex cursor-pointer items-center gap-2">
         <input
           type="checkbox"

--- a/src/components/TaskForm.tsx
+++ b/src/components/TaskForm.tsx
@@ -1337,9 +1337,6 @@ export function TaskForm({
             {workspaceError}
           </p>
         ) : null}
-        <p className="mt-2 text-ui-sm text-tier-tertiary">
-          Each run starts from the locally known base revision in its own clean checkout.
-        </p>
         {v.resumeSessionId ? (
           <button
             type="button"

--- a/src/components/WorkspaceReadiness.tsx
+++ b/src/components/WorkspaceReadiness.tsx
@@ -76,30 +76,34 @@ export function WorkspaceReadiness({ task }: { task: TaskWithMeta }) {
       : 'Ready to Run'
 
   return (
-    <section>
+    <div className="contents">
       <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
-        <Button
-          type="button"
-          variant="ghost"
-          aria-expanded={open}
-          onClick={() => setOpen((v) => !v)}
-        >
-          {blocked ? (
-            <AlertTriangle className="h-3.5 w-3.5 text-danger" />
-          ) : (
-            <CheckCircle2 className="h-3.5 w-3.5 text-success" />
-          )}
-          {title}
-        </Button>
-        {!open ? (
+        {blocked && !open ? (
           <span className="text-ui-sm text-tier-quaternary">
             {readinessSummary(task, blockers)}
           </span>
         ) : null}
+        <Button
+          type="button"
+          variant="ghost"
+          aria-expanded={open}
+          aria-label={title}
+          title={title}
+          onClick={() => setOpen((v) => !v)}
+        >
+          {blocked ? (
+            <>
+              <AlertTriangle className="h-3.5 w-3.5 text-danger" />
+              {title}
+            </>
+          ) : (
+            <CheckCircle2 className="h-3.5 w-3.5 text-success" />
+          )}
+        </Button>
       </div>
 
       {!open ? null : (
-        <Card className="mt-2 p-4">
+        <Card className="mt-2 w-full basis-full p-4">
           {blocked ? (
             <ul className="mb-3 space-y-1 text-ui-sm leading-relaxed text-tier-secondary">
               {blockers.map((blocker, index) => (
@@ -244,7 +248,7 @@ export function WorkspaceReadiness({ task }: { task: TaskWithMeta }) {
           </div>
         </Card>
       )}
-    </section>
+    </div>
   )
 }
 

--- a/src/routes/tasks.$taskId.tsx
+++ b/src/routes/tasks.$taskId.tsx
@@ -99,7 +99,6 @@ function TaskDetail() {
         readiness={demo ? undefined : <WorkspaceReadiness task={task} />}
         workspaceChangeBlockedReason={taskWorkspaceChangeBlockedReason(task)}
         demoPreview={demo}
-        onCancel={() => navigate({ to: '/tasks' })}
         onSaved={() => {
           if (demo) return
           qc.invalidateQueries({ queryKey: ['task', taskId] })

--- a/src/routes/tasks.new.tsx
+++ b/src/routes/tasks.new.tsx
@@ -74,7 +74,6 @@ function NewTaskPage() {
     <div className="px-8 py-8">
       <TaskForm
         initial={initial}
-        onCancel={() => navigate({ to: '/tasks' })}
         onSaved={(id) => navigate({ to: '/tasks/$taskId', params: { taskId: id } })}
       />
     </div>


### PR DESCRIPTION
## Summary
- The automation form no longer shows a Cancel button; leave via the Automations breadcrumb instead.
- Workspace readiness sits on the same row as the verification toggle when the project is saved, with a compact ready icon and blocker summary before the expand control.

## Test plan
- [ ] Open `/tasks/new` — no Cancel button in the header; Save still works and breadcrumb returns to the list
- [ ] Open a saved automation with a green readiness state — a check icon appears inline with the verification row; click it to expand workspace details
- [ ] Open an automation with readiness blockers — the summary appears before the warning button; expanding still shows blockers and repair actions
- [ ] Change the project without saving — the "Project Change Not Saved" card still appears below the steps instead of inline readiness