### PR TITLE
feat(terminal): add interactive workspace shell

### DIFF
--- a/changelog.d/embedded-terminal.md
+++ b/changelog.d/embedded-terminal.md
@@ -1,0 +1,1 @@
+You no longer need to leave a run to use its checkout: the workspace now includes an interactive terminal for switching branches and running commands, with clean resize and close controls.

--- a/package.json
+++ b/package.json
@@ -68,6 +68,8 @@
     "@tanstack/react-router": "^1.170.32",
     "@tanstack/react-start": "^1.168.49",
     "@uiw/react-codemirror": "^4.25.11",
+    "@xterm/addon-fit": "^0.11.0",
+    "@xterm/xterm": "^6.0.0",
     "better-sqlite3": "^13.0.3",
     "cron-parser": "^4.9.0",
     "lucide-react": "^1.37.0",
@@ -78,7 +80,8 @@
     "react-markdown": "^10.1.0",
     "remark-gfm": "^4.0.1",
     "simple-icons": "^16.29.0",
-    "tailwindcss": "^4.1.18"
+    "tailwindcss": "^4.1.18",
+    "zigpty": "^0.2.1"
   },
   "devDependencies": {
     "@agentclientprotocol/sdk": "1.4.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,6 +69,12 @@ importers:
       '@uiw/react-codemirror':
         specifier: ^4.25.11
         version: 4.25.11(@babel/runtime@8.0.0)(@codemirror/autocomplete@6.20.3)(@codemirror/language@6.12.4)(@codemirror/lint@6.9.7)(@codemirror/search@6.7.1)(@codemirror/state@6.7.1)(@codemirror/theme-one-dark@6.1.3)(@codemirror/view@6.43.9)(codemirror@6.0.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@xterm/addon-fit':
+        specifier: ^0.11.0
+        version: 0.11.0
+      '@xterm/xterm':
+        specifier: ^6.0.0
+        version: 6.0.0
       better-sqlite3:
         specifier: ^13.0.3
         version: 13.0.3
@@ -102,6 +108,9 @@ importers:
       tailwindcss:
         specifier: ^4.1.18
         version: 4.3.3
+      zigpty:
+        specifier: ^0.2.1
+        version: 0.2.1
     devDependencies:
       '@agentclientprotocol/sdk':
         specifier: 1.4.0
@@ -1087,6 +1096,12 @@ packages:
       oxc-transform-react:
         optional: true
 
+  '@xterm/addon-fit@0.11.0':
+    resolution: {integrity: sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g==}
+
+  '@xterm/xterm@6.0.0':
+    resolution: {integrity: sha512-TQwDdQGtwwDt+2cgKDLn0IRaSxYu1tSUjgKarSDkUM0ZNiSRXFpjxEsvc/Zgc5kq5omJ+V0a8/kIM2WD3sMOYg==}
+
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
@@ -2018,6 +2033,9 @@ packages:
   yargs@15.4.1:
     resolution: {integrity: sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==}
     engines: {node: '>=8'}
+
+  zigpty@0.2.1:
+    resolution: {integrity: sha512-MR9JqJx2wf5f4wz8zpx050AlqrmWeIW+1h0SO5iEyhG3HFRjY5luC3szS2ux2EGuPjE5OU9ZAuiCBeMWBTrqZw==}
 
   zod@4.4.3:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
@@ -3018,6 +3036,10 @@ snapshots:
     dependencies:
       '@rolldown/pluginutils': 1.0.1
       vite: 8.2.2(@types/node@26.4.1)(jiti@2.7.0)
+
+  '@xterm/addon-fit@0.11.0': {}
+
+  '@xterm/xterm@6.0.0': {}
 
   ansi-regex@5.0.1: {}
 
@@ -4086,6 +4108,8 @@ snapshots:
       which-module: 2.0.1
       y18n: 4.0.3
       yargs-parser: 18.1.3
+
+  zigpty@0.2.1: {}
 
   zod@4.4.3: {}
 

--- a/src/components/workspace/TerminalDrawer.tsx
+++ b/src/components/workspace/TerminalDrawer.tsx
@@ -1,32 +1,43 @@
+import { FitAddon } from '@xterm/addon-fit'
+import { Terminal as XtermTerminal } from '@xterm/xterm'
+import { Terminal, X } from 'lucide-react'
 import { useCallback, useEffect, useRef, useState } from 'react'
-import { Terminal } from 'lucide-react'
 
 const MIN_HEIGHT = 120
 const MAX_HEIGHT = 480
 const DEFAULT_HEIGHT = 220
 
+type StreamEvent =
+  | { type: 'data'; data: string }
+  | { type: 'exit'; exitCode: number; signal: number }
+
+async function responseError(response: Response): Promise<string> {
+  const body = (await response.json().catch(() => null)) as { error?: string } | null
+  return body?.error ?? `Terminal request failed (${response.status})`
+}
+
 export function TerminalDrawer({
   open,
   height,
   onHeightChange,
-  command,
-  stdout,
-  stderr,
+  onClose,
+  workspaceId,
 }: {
   open: boolean
   height: number
   onHeightChange: (h: number) => void
-  command: string
-  stdout: string
-  stderr: string
+  onClose: () => void
+  workspaceId?: string
 }) {
   const dragRef = useRef<{ startY: number; startH: number } | null>(null)
+  const terminalHostRef = useRef<HTMLDivElement>(null)
   const [dragging, setDragging] = useState(false)
+  const [error, setError] = useState<string | null>(null)
 
   const onPointerMove = useCallback(
-    (e: PointerEvent) => {
+    (event: PointerEvent) => {
       if (!dragRef.current) return
-      const delta = dragRef.current.startY - e.clientY
+      const delta = dragRef.current.startY - event.clientY
       const next = Math.min(MAX_HEIGHT, Math.max(MIN_HEIGHT, dragRef.current.startH + delta))
       onHeightChange(next)
     },
@@ -48,56 +59,162 @@ export function TerminalDrawer({
     }
   }, [dragging, onPointerMove, onPointerUp])
 
+  useEffect(() => {
+    if (!open || !workspaceId || !terminalHostRef.current) return
+    setError(null)
+
+    let disposed = false
+    let sessionId: string | null = null
+    let source: EventSource | null = null
+    let resizeTimer: ReturnType<typeof setTimeout> | null = null
+    let inputTimer: ReturnType<typeof setTimeout> | null = null
+    let pendingInput = ''
+    let inputChain = Promise.resolve()
+    const terminal = new XtermTerminal({
+      cursorBlink: true,
+      fontFamily: 'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace',
+      fontSize: 12,
+      scrollback: 5_000,
+      theme: { background: '#101010', foreground: '#d6d6dd', cursor: '#f0f0f0' },
+    })
+    const fit = new FitAddon()
+    terminal.loadAddon(fit)
+    terminal.open(terminalHostRef.current)
+    fit.fit()
+    terminal.focus()
+
+    const sendInput = () => {
+      inputTimer = null
+      if (!sessionId || !pendingInput) return
+      const data = pendingInput
+      pendingInput = ''
+      const id = sessionId
+      inputChain = inputChain
+        .then(async () => {
+          const response = await fetch(`/api/terminals/${encodeURIComponent(id)}/input`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'text/plain; charset=utf-8' },
+            body: data,
+          })
+          if (!response.ok) throw new Error(await responseError(response))
+        })
+        .catch(() => setError('The terminal connection was lost.'))
+    }
+    const dataDisposable = terminal.onData((data) => {
+      pendingInput += data
+      if (!inputTimer) inputTimer = setTimeout(sendInput, 8)
+    })
+
+    const resize = () => {
+      fit.fit()
+      if (!sessionId) return
+      if (resizeTimer) clearTimeout(resizeTimer)
+      resizeTimer = setTimeout(() => {
+        void fetch(`/api/terminals/${encodeURIComponent(sessionId!)}/resize`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ cols: terminal.cols, rows: terminal.rows }),
+        })
+      }, 50)
+    }
+    const observer = new ResizeObserver(resize)
+    observer.observe(terminalHostRef.current)
+
+    void fetch('/api/terminals/', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ workspaceId, cols: terminal.cols, rows: terminal.rows }),
+    })
+      .then(async (response) => {
+        if (!response.ok) throw new Error(await responseError(response))
+        return response.json() as Promise<{ id: string }>
+      })
+      .then(({ id }) => {
+        if (disposed) {
+          void fetch(`/api/terminals/${encodeURIComponent(id)}/`, { method: 'DELETE' })
+          return
+        }
+        sessionId = id
+        sendInput()
+        source = new EventSource(`/api/terminals/${encodeURIComponent(id)}/stream`)
+        source.onmessage = (message) => {
+          const event = JSON.parse(message.data) as StreamEvent
+          if (event.type === 'data') terminal.write(event.data)
+          if (event.type === 'exit') {
+            terminal.writeln(`\r\n[process exited with code ${event.exitCode}]`)
+            source?.close()
+          }
+        }
+        source.onerror = () => {
+          if (!disposed) setError('The terminal connection was lost.')
+        }
+      })
+      .catch((reason: unknown) => {
+        if (!disposed) setError(reason instanceof Error ? reason.message : String(reason))
+      })
+
+    return () => {
+      disposed = true
+      source?.close()
+      observer.disconnect()
+      dataDisposable.dispose()
+      if (resizeTimer) clearTimeout(resizeTimer)
+      if (inputTimer) clearTimeout(inputTimer)
+      terminal.dispose()
+      if (sessionId) {
+        void fetch(`/api/terminals/${encodeURIComponent(sessionId)}/`, {
+          method: 'DELETE',
+          keepalive: true,
+        })
+      }
+    }
+  }, [open, workspaceId])
+
   if (!open) return null
 
-  const log = [stdout, stderr].filter(Boolean).join('\n')
   const h = height || DEFAULT_HEIGHT
-
   return (
     <div
-      className="flex shrink-0 flex-col border-t border-border bg-[color-mix(in_srgb,var(--chrome)_92%,black)]"
+      className="flex shrink-0 flex-col border-t border-border bg-[#101010]"
       style={{ height: h }}
     >
       <div
         role="separator"
         aria-orientation="horizontal"
-        onPointerDown={(e) => {
-          dragRef.current = { startY: e.clientY, startH: h }
+        onPointerDown={(event) => {
+          dragRef.current = { startY: event.clientY, startH: h }
           setDragging(true)
-          e.currentTarget.setPointerCapture?.(e.pointerId)
+          event.currentTarget.setPointerCapture?.(event.pointerId)
         }}
         className="group flex h-2 cursor-ns-resize items-center justify-center"
       >
         <div className="h-0.5 w-10 rounded-full bg-border transition-colors group-hover:bg-muted-foreground/50" />
       </div>
-
       <div className="flex items-center gap-2 border-b border-border/60 px-3 pb-1.5">
         <Terminal className="size-3.5 text-muted-foreground" />
         <span className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
           Terminal
         </span>
-        <span className="text-[10px] text-muted-foreground/50">
-          read-only · interactive PTY soon
+        <span className="min-w-0 flex-1 truncate text-[10px] text-muted-foreground/50">
+          {error ?? 'interactive shell · active workspace'}
         </span>
+        <button
+          type="button"
+          aria-label="Close terminal"
+          title="Close terminal"
+          onClick={onClose}
+          className="rounded p-0.5 text-muted-foreground hover:bg-secondary hover:text-foreground"
+        >
+          <X className="size-3.5" />
+        </button>
       </div>
-
-      <div className="scroll-thin min-h-0 flex-1 overflow-auto px-3 py-2 mono text-[11.5px] leading-relaxed">
-        {command ? (
-          <div className="mb-2 text-emerald-300/80">
-            <span className="text-muted-foreground/60">$ </span>
-            {command}
-          </div>
-        ) : null}
-        {log ? (
-          <pre className="whitespace-pre-wrap break-words text-muted-foreground">
-            {log.slice(-12000)}
-          </pre>
-        ) : (
-          <div className="py-6 text-center text-[12px] text-muted-foreground/50">
-            No process output yet. Agent stdout/stderr will appear here.
-          </div>
-        )}
-      </div>
+      {workspaceId ? (
+        <div ref={terminalHostRef} className="min-h-0 flex-1 overflow-hidden px-1 py-1" />
+      ) : (
+        <div className="py-6 text-center text-[12px] text-muted-foreground/50">
+          This run has no active workspace.
+        </div>
+      )}
     </div>
   )
 }

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -33,6 +33,7 @@ import { Route as ApiMobileMeRouteImport } from './routes/api/mobile/me'
 import { Route as ApiMobilePairRouteImport } from './routes/api/mobile/pair'
 import { Route as ApiMobileStartOptionsRouteImport } from './routes/api/mobile/start-options'
 import { Route as ApiMobileUnpairRouteImport } from './routes/api/mobile/unpair'
+import { Route as ApiTerminalsIndexRouteImport } from './routes/api/terminals/index'
 import { Route as ApiV1SplatRouteImport } from './routes/api/v1/$'
 import { Route as ApiMcpOauthCallbackRouteImport } from './routes/api/mcp/oauth/callback'
 import { Route as ApiMobileActivityStreamRouteImport } from './routes/api/mobile/activity.stream'
@@ -42,6 +43,10 @@ import { Route as ApiMobileTasksIndexRouteImport } from './routes/api/mobile/tas
 import { Route as ApiRunsRunIdAttachmentRouteImport } from './routes/api/runs/$runId/attachment'
 import { Route as ApiRunsRunIdStreamRouteImport } from './routes/api/runs/$runId/stream'
 import { Route as ApiRunsRunIdUiStreamRouteImport } from './routes/api/runs/$runId/ui-stream'
+import { Route as ApiTerminalsSessionIdIndexRouteImport } from './routes/api/terminals/$sessionId/index'
+import { Route as ApiTerminalsSessionIdInputRouteImport } from './routes/api/terminals/$sessionId/input'
+import { Route as ApiTerminalsSessionIdResizeRouteImport } from './routes/api/terminals/$sessionId/resize'
+import { Route as ApiTerminalsSessionIdStreamRouteImport } from './routes/api/terminals/$sessionId/stream'
 import { Route as ApiMobileRunsRunIdIndexRouteImport } from './routes/api/mobile/runs/$runId/index'
 import { Route as ApiMobileRunsRunIdApprovalsRouteImport } from './routes/api/mobile/runs/$runId/approvals'
 import { Route as ApiMobileRunsRunIdCancelRouteImport } from './routes/api/mobile/runs/$runId/cancel'
@@ -174,6 +179,11 @@ const ApiMobileUnpairRoute = ApiMobileUnpairRouteImport.update({
   path: '/api/mobile/unpair',
   getParentRoute: () => rootRouteImport,
 } as any)
+const ApiTerminalsIndexRoute = ApiTerminalsIndexRouteImport.update({
+  id: '/api/terminals/',
+  path: '/api/terminals/',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ApiV1SplatRoute = ApiV1SplatRouteImport.update({
   id: '/api/v1/$',
   path: '/api/v1/$',
@@ -219,6 +229,30 @@ const ApiRunsRunIdUiStreamRoute = ApiRunsRunIdUiStreamRouteImport.update({
   path: '/api/runs/$runId/ui-stream',
   getParentRoute: () => rootRouteImport,
 } as any)
+const ApiTerminalsSessionIdIndexRoute =
+  ApiTerminalsSessionIdIndexRouteImport.update({
+    id: '/api/terminals/$sessionId/',
+    path: '/api/terminals/$sessionId/',
+    getParentRoute: () => rootRouteImport,
+  } as any)
+const ApiTerminalsSessionIdInputRoute =
+  ApiTerminalsSessionIdInputRouteImport.update({
+    id: '/api/terminals/$sessionId/input',
+    path: '/api/terminals/$sessionId/input',
+    getParentRoute: () => rootRouteImport,
+  } as any)
+const ApiTerminalsSessionIdResizeRoute =
+  ApiTerminalsSessionIdResizeRouteImport.update({
+    id: '/api/terminals/$sessionId/resize',
+    path: '/api/terminals/$sessionId/resize',
+    getParentRoute: () => rootRouteImport,
+  } as any)
+const ApiTerminalsSessionIdStreamRoute =
+  ApiTerminalsSessionIdStreamRouteImport.update({
+    id: '/api/terminals/$sessionId/stream',
+    path: '/api/terminals/$sessionId/stream',
+    getParentRoute: () => rootRouteImport,
+  } as any)
 const ApiMobileRunsRunIdIndexRoute = ApiMobileRunsRunIdIndexRouteImport.update({
   id: '/api/mobile/runs/$runId/',
   path: '/api/mobile/runs/$runId/',
@@ -308,14 +342,19 @@ export interface FileRoutesByFullPath {
   '/api/mobile/start-options': typeof ApiMobileStartOptionsRoute
   '/api/mobile/unpair': typeof ApiMobileUnpairRoute
   '/api/v1/$': typeof ApiV1SplatRoute
+  '/api/terminals/': typeof ApiTerminalsIndexRoute
   '/api/mcp/oauth/callback': typeof ApiMcpOauthCallbackRoute
   '/api/mobile/activity/stream': typeof ApiMobileActivityStreamRoute
   '/api/mobile/push/register': typeof ApiMobilePushRegisterRoute
   '/api/runs/$runId/attachment': typeof ApiRunsRunIdAttachmentRoute
   '/api/runs/$runId/stream': typeof ApiRunsRunIdStreamRoute
   '/api/runs/$runId/ui-stream': typeof ApiRunsRunIdUiStreamRoute
+  '/api/terminals/$sessionId/input': typeof ApiTerminalsSessionIdInputRoute
+  '/api/terminals/$sessionId/resize': typeof ApiTerminalsSessionIdResizeRoute
+  '/api/terminals/$sessionId/stream': typeof ApiTerminalsSessionIdStreamRoute
   '/api/mobile/runs/': typeof ApiMobileRunsIndexRoute
   '/api/mobile/tasks/': typeof ApiMobileTasksIndexRoute
+  '/api/terminals/$sessionId/': typeof ApiTerminalsSessionIdIndexRoute
   '/api/mobile/runs/$runId/approvals': typeof ApiMobileRunsRunIdApprovalsRoute
   '/api/mobile/runs/$runId/cancel': typeof ApiMobileRunsRunIdCancelRoute
   '/api/mobile/runs/$runId/diff': typeof ApiMobileRunsRunIdDiffRouteWithChildren
@@ -353,14 +392,19 @@ export interface FileRoutesByTo {
   '/api/mobile/start-options': typeof ApiMobileStartOptionsRoute
   '/api/mobile/unpair': typeof ApiMobileUnpairRoute
   '/api/v1/$': typeof ApiV1SplatRoute
+  '/api/terminals': typeof ApiTerminalsIndexRoute
   '/api/mcp/oauth/callback': typeof ApiMcpOauthCallbackRoute
   '/api/mobile/activity/stream': typeof ApiMobileActivityStreamRoute
   '/api/mobile/push/register': typeof ApiMobilePushRegisterRoute
   '/api/runs/$runId/attachment': typeof ApiRunsRunIdAttachmentRoute
   '/api/runs/$runId/stream': typeof ApiRunsRunIdStreamRoute
   '/api/runs/$runId/ui-stream': typeof ApiRunsRunIdUiStreamRoute
+  '/api/terminals/$sessionId/input': typeof ApiTerminalsSessionIdInputRoute
+  '/api/terminals/$sessionId/resize': typeof ApiTerminalsSessionIdResizeRoute
+  '/api/terminals/$sessionId/stream': typeof ApiTerminalsSessionIdStreamRoute
   '/api/mobile/runs': typeof ApiMobileRunsIndexRoute
   '/api/mobile/tasks': typeof ApiMobileTasksIndexRoute
+  '/api/terminals/$sessionId': typeof ApiTerminalsSessionIdIndexRoute
   '/api/mobile/runs/$runId/approvals': typeof ApiMobileRunsRunIdApprovalsRoute
   '/api/mobile/runs/$runId/cancel': typeof ApiMobileRunsRunIdCancelRoute
   '/api/mobile/runs/$runId/diff': typeof ApiMobileRunsRunIdDiffRouteWithChildren
@@ -400,14 +444,19 @@ export interface FileRoutesById {
   '/api/mobile/start-options': typeof ApiMobileStartOptionsRoute
   '/api/mobile/unpair': typeof ApiMobileUnpairRoute
   '/api/v1/$': typeof ApiV1SplatRoute
+  '/api/terminals/': typeof ApiTerminalsIndexRoute
   '/api/mcp/oauth/callback': typeof ApiMcpOauthCallbackRoute
   '/api/mobile/activity/stream': typeof ApiMobileActivityStreamRoute
   '/api/mobile/push/register': typeof ApiMobilePushRegisterRoute
   '/api/runs/$runId/attachment': typeof ApiRunsRunIdAttachmentRoute
   '/api/runs/$runId/stream': typeof ApiRunsRunIdStreamRoute
   '/api/runs/$runId/ui-stream': typeof ApiRunsRunIdUiStreamRoute
+  '/api/terminals/$sessionId/input': typeof ApiTerminalsSessionIdInputRoute
+  '/api/terminals/$sessionId/resize': typeof ApiTerminalsSessionIdResizeRoute
+  '/api/terminals/$sessionId/stream': typeof ApiTerminalsSessionIdStreamRoute
   '/api/mobile/runs/': typeof ApiMobileRunsIndexRoute
   '/api/mobile/tasks/': typeof ApiMobileTasksIndexRoute
+  '/api/terminals/$sessionId/': typeof ApiTerminalsSessionIdIndexRoute
   '/api/mobile/runs/$runId/approvals': typeof ApiMobileRunsRunIdApprovalsRoute
   '/api/mobile/runs/$runId/cancel': typeof ApiMobileRunsRunIdCancelRoute
   '/api/mobile/runs/$runId/diff': typeof ApiMobileRunsRunIdDiffRouteWithChildren
@@ -448,14 +497,19 @@ export interface FileRouteTypes {
     | '/api/mobile/start-options'
     | '/api/mobile/unpair'
     | '/api/v1/$'
+    | '/api/terminals/'
     | '/api/mcp/oauth/callback'
     | '/api/mobile/activity/stream'
     | '/api/mobile/push/register'
     | '/api/runs/$runId/attachment'
     | '/api/runs/$runId/stream'
     | '/api/runs/$runId/ui-stream'
+    | '/api/terminals/$sessionId/input'
+    | '/api/terminals/$sessionId/resize'
+    | '/api/terminals/$sessionId/stream'
     | '/api/mobile/runs/'
     | '/api/mobile/tasks/'
+    | '/api/terminals/$sessionId/'
     | '/api/mobile/runs/$runId/approvals'
     | '/api/mobile/runs/$runId/cancel'
     | '/api/mobile/runs/$runId/diff'
@@ -493,14 +547,19 @@ export interface FileRouteTypes {
     | '/api/mobile/start-options'
     | '/api/mobile/unpair'
     | '/api/v1/$'
+    | '/api/terminals'
     | '/api/mcp/oauth/callback'
     | '/api/mobile/activity/stream'
     | '/api/mobile/push/register'
     | '/api/runs/$runId/attachment'
     | '/api/runs/$runId/stream'
     | '/api/runs/$runId/ui-stream'
+    | '/api/terminals/$sessionId/input'
+    | '/api/terminals/$sessionId/resize'
+    | '/api/terminals/$sessionId/stream'
     | '/api/mobile/runs'
     | '/api/mobile/tasks'
+    | '/api/terminals/$sessionId'
     | '/api/mobile/runs/$runId/approvals'
     | '/api/mobile/runs/$runId/cancel'
     | '/api/mobile/runs/$runId/diff'
@@ -539,14 +598,19 @@ export interface FileRouteTypes {
     | '/api/mobile/start-options'
     | '/api/mobile/unpair'
     | '/api/v1/$'
+    | '/api/terminals/'
     | '/api/mcp/oauth/callback'
     | '/api/mobile/activity/stream'
     | '/api/mobile/push/register'
     | '/api/runs/$runId/attachment'
     | '/api/runs/$runId/stream'
     | '/api/runs/$runId/ui-stream'
+    | '/api/terminals/$sessionId/input'
+    | '/api/terminals/$sessionId/resize'
+    | '/api/terminals/$sessionId/stream'
     | '/api/mobile/runs/'
     | '/api/mobile/tasks/'
+    | '/api/terminals/$sessionId/'
     | '/api/mobile/runs/$runId/approvals'
     | '/api/mobile/runs/$runId/cancel'
     | '/api/mobile/runs/$runId/diff'
@@ -584,14 +648,19 @@ export interface RootRouteChildren {
   ApiMobileStartOptionsRoute: typeof ApiMobileStartOptionsRoute
   ApiMobileUnpairRoute: typeof ApiMobileUnpairRoute
   ApiV1SplatRoute: typeof ApiV1SplatRoute
+  ApiTerminalsIndexRoute: typeof ApiTerminalsIndexRoute
   ApiMcpOauthCallbackRoute: typeof ApiMcpOauthCallbackRoute
   ApiMobileActivityStreamRoute: typeof ApiMobileActivityStreamRoute
   ApiMobilePushRegisterRoute: typeof ApiMobilePushRegisterRoute
   ApiRunsRunIdAttachmentRoute: typeof ApiRunsRunIdAttachmentRoute
   ApiRunsRunIdStreamRoute: typeof ApiRunsRunIdStreamRoute
   ApiRunsRunIdUiStreamRoute: typeof ApiRunsRunIdUiStreamRoute
+  ApiTerminalsSessionIdInputRoute: typeof ApiTerminalsSessionIdInputRoute
+  ApiTerminalsSessionIdResizeRoute: typeof ApiTerminalsSessionIdResizeRoute
+  ApiTerminalsSessionIdStreamRoute: typeof ApiTerminalsSessionIdStreamRoute
   ApiMobileRunsIndexRoute: typeof ApiMobileRunsIndexRoute
   ApiMobileTasksIndexRoute: typeof ApiMobileTasksIndexRoute
+  ApiTerminalsSessionIdIndexRoute: typeof ApiTerminalsSessionIdIndexRoute
   ApiMobileRunsRunIdApprovalsRoute: typeof ApiMobileRunsRunIdApprovalsRoute
   ApiMobileRunsRunIdCancelRoute: typeof ApiMobileRunsRunIdCancelRoute
   ApiMobileRunsRunIdDiffRoute: typeof ApiMobileRunsRunIdDiffRouteWithChildren
@@ -773,6 +842,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiMobileUnpairRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/api/terminals/': {
+      id: '/api/terminals/'
+      path: '/api/terminals'
+      fullPath: '/api/terminals/'
+      preLoaderRoute: typeof ApiTerminalsIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/api/v1/$': {
       id: '/api/v1/$'
       path: '/api/v1/$'
@@ -834,6 +910,34 @@ declare module '@tanstack/react-router' {
       path: '/api/runs/$runId/ui-stream'
       fullPath: '/api/runs/$runId/ui-stream'
       preLoaderRoute: typeof ApiRunsRunIdUiStreamRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/terminals/$sessionId/': {
+      id: '/api/terminals/$sessionId/'
+      path: '/api/terminals/$sessionId'
+      fullPath: '/api/terminals/$sessionId/'
+      preLoaderRoute: typeof ApiTerminalsSessionIdIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/terminals/$sessionId/input': {
+      id: '/api/terminals/$sessionId/input'
+      path: '/api/terminals/$sessionId/input'
+      fullPath: '/api/terminals/$sessionId/input'
+      preLoaderRoute: typeof ApiTerminalsSessionIdInputRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/terminals/$sessionId/resize': {
+      id: '/api/terminals/$sessionId/resize'
+      path: '/api/terminals/$sessionId/resize'
+      fullPath: '/api/terminals/$sessionId/resize'
+      preLoaderRoute: typeof ApiTerminalsSessionIdResizeRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/terminals/$sessionId/stream': {
+      id: '/api/terminals/$sessionId/stream'
+      path: '/api/terminals/$sessionId/stream'
+      fullPath: '/api/terminals/$sessionId/stream'
+      preLoaderRoute: typeof ApiTerminalsSessionIdStreamRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/api/mobile/runs/$runId/': {
@@ -982,14 +1086,19 @@ const rootRouteChildren: RootRouteChildren = {
   ApiMobileStartOptionsRoute: ApiMobileStartOptionsRoute,
   ApiMobileUnpairRoute: ApiMobileUnpairRoute,
   ApiV1SplatRoute: ApiV1SplatRoute,
+  ApiTerminalsIndexRoute: ApiTerminalsIndexRoute,
   ApiMcpOauthCallbackRoute: ApiMcpOauthCallbackRoute,
   ApiMobileActivityStreamRoute: ApiMobileActivityStreamRoute,
   ApiMobilePushRegisterRoute: ApiMobilePushRegisterRoute,
   ApiRunsRunIdAttachmentRoute: ApiRunsRunIdAttachmentRoute,
   ApiRunsRunIdStreamRoute: ApiRunsRunIdStreamRoute,
   ApiRunsRunIdUiStreamRoute: ApiRunsRunIdUiStreamRoute,
+  ApiTerminalsSessionIdInputRoute: ApiTerminalsSessionIdInputRoute,
+  ApiTerminalsSessionIdResizeRoute: ApiTerminalsSessionIdResizeRoute,
+  ApiTerminalsSessionIdStreamRoute: ApiTerminalsSessionIdStreamRoute,
   ApiMobileRunsIndexRoute: ApiMobileRunsIndexRoute,
   ApiMobileTasksIndexRoute: ApiMobileTasksIndexRoute,
+  ApiTerminalsSessionIdIndexRoute: ApiTerminalsSessionIdIndexRoute,
   ApiMobileRunsRunIdApprovalsRoute: ApiMobileRunsRunIdApprovalsRoute,
   ApiMobileRunsRunIdCancelRoute: ApiMobileRunsRunIdCancelRoute,
   ApiMobileRunsRunIdDiffRoute: ApiMobileRunsRunIdDiffRouteWithChildren,

--- a/src/routes/api/terminals/$sessionId/index.ts
+++ b/src/routes/api/terminals/$sessionId/index.ts
@@ -1,0 +1,13 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { closeTerminalSession } from '#/server/terminalSessions'
+
+export const Route = createFileRoute('/api/terminals/$sessionId/')({
+  server: {
+    handlers: {
+      DELETE: ({ params }) => {
+        closeTerminalSession(params.sessionId)
+        return new Response(null, { status: 204 })
+      },
+    },
+  },
+})

--- a/src/routes/api/terminals/$sessionId/input.ts
+++ b/src/routes/api/terminals/$sessionId/input.ts
@@ -1,0 +1,21 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { writeTerminalSession } from '#/server/terminalSessions'
+
+export const Route = createFileRoute('/api/terminals/$sessionId/input')({
+  server: {
+    handlers: {
+      POST: async ({ params, request }) => {
+        try {
+          const data = await request.text()
+          writeTerminalSession(params.sessionId, data)
+          return new Response(null, { status: 204 })
+        } catch (error) {
+          return Response.json(
+            { error: error instanceof Error ? error.message : String(error) },
+            { status: 404 },
+          )
+        }
+      },
+    },
+  },
+})

--- a/src/routes/api/terminals/$sessionId/resize.ts
+++ b/src/routes/api/terminals/$sessionId/resize.ts
@@ -1,0 +1,21 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { resizeTerminalSession } from '#/server/terminalSessions'
+
+export const Route = createFileRoute('/api/terminals/$sessionId/resize')({
+  server: {
+    handlers: {
+      POST: async ({ params, request }) => {
+        try {
+          const body = (await request.json()) as { cols?: number; rows?: number }
+          resizeTerminalSession(params.sessionId, body.cols, body.rows)
+          return new Response(null, { status: 204 })
+        } catch (error) {
+          return Response.json(
+            { error: error instanceof Error ? error.message : String(error) },
+            { status: 404 },
+          )
+        }
+      },
+    },
+  },
+})

--- a/src/routes/api/terminals/$sessionId/stream.ts
+++ b/src/routes/api/terminals/$sessionId/stream.ts
@@ -1,0 +1,26 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { createTerminalStream } from '#/server/terminalStream'
+
+export const Route = createFileRoute('/api/terminals/$sessionId/stream')({
+  server: {
+    handlers: {
+      GET: ({ params, request }) => {
+        try {
+          return new Response(createTerminalStream(params.sessionId, request.signal), {
+            headers: {
+              'Content-Type': 'text/event-stream; charset=utf-8',
+              'Cache-Control': 'no-cache, no-transform',
+              Connection: 'keep-alive',
+              'X-Accel-Buffering': 'no',
+            },
+          })
+        } catch (error) {
+          return Response.json(
+            { error: error instanceof Error ? error.message : String(error) },
+            { status: 404 },
+          )
+        }
+      },
+    },
+  },
+})

--- a/src/routes/api/terminals/index.ts
+++ b/src/routes/api/terminals/index.ts
@@ -1,0 +1,29 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { createTerminalSession } from '#/server/terminalSessions'
+
+export const Route = createFileRoute('/api/terminals/')({
+  server: {
+    handlers: {
+      POST: async ({ request }) => {
+        try {
+          const body = (await request.json()) as {
+            workspaceId?: string
+            cols?: number
+            rows?: number
+          }
+          const result = createTerminalSession({
+            workspaceId: body.workspaceId ?? '',
+            cols: body.cols,
+            rows: body.rows,
+          })
+          return Response.json(result, { status: 201 })
+        } catch (error) {
+          return Response.json(
+            { error: error instanceof Error ? error.message : String(error) },
+            { status: 400 },
+          )
+        }
+      },
+    },
+  },
+})

--- a/src/routes/runs.$runId.tsx
+++ b/src/routes/runs.$runId.tsx
@@ -5,7 +5,7 @@
  * Panel chrome adapted from t3code ChatView (MIT, T3 Tools Inc.).
  */
 import { createFileRoute, Link, useNavigate } from '@tanstack/react-router'
-import { ArrowLeft, Ban, MoreHorizontal, Plus, RotateCcw, Trash2 } from 'lucide-react'
+import { ArrowLeft, Ban, MoreHorizontal, Plus, RotateCcw, Terminal, Trash2 } from 'lucide-react'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { useQueryClient } from '@tanstack/react-query'
 import * as fns from '../fns'
@@ -453,6 +453,21 @@ function RunDetail() {
               />
 
               <div className="flex shrink-0 items-center gap-0.5">
+                <button
+                  type="button"
+                  onClick={() => patchLayout({ terminalOpen: !layout.terminalOpen })}
+                  disabled={!workspace?.id}
+                  aria-label="Toggle terminal"
+                  aria-pressed={layout.terminalOpen}
+                  title={workspace?.id ? 'Toggle terminal' : 'This run has no active workspace'}
+                  className={`inline-flex size-7 items-center justify-center rounded-md transition-colors disabled:opacity-40 ${
+                    layout.terminalOpen
+                      ? 'bg-secondary text-foreground'
+                      : 'text-muted-foreground hover:bg-secondary hover:text-foreground'
+                  }`}
+                >
+                  <Terminal className="size-3.5" />
+                </button>
                 {run?.status === 'running' ? (
                   <button
                     type="button"
@@ -798,9 +813,8 @@ function RunDetail() {
         open={layout.terminalOpen}
         height={layout.terminalHeight}
         onHeightChange={(terminalHeight) => patchLayout({ terminalHeight })}
-        command={run?.command ?? ''}
-        stdout={run?.stdout ?? ''}
-        stderr={run?.stderr ?? ''}
+        onClose={() => patchLayout({ terminalOpen: false })}
+        workspaceId={workspace?.id ?? run?.workspaceId}
       />
 
       {confirmDelete && run ? (

--- a/src/server/terminalSessions.ts
+++ b/src/server/terminalSessions.ts
@@ -1,0 +1,120 @@
+import { randomUUID } from 'node:crypto'
+import { spawn, type IPty } from 'zigpty'
+import { resolveWorkspacePath } from './workspaces.ts'
+
+const MAX_BUFFER_CHARS = 64_000
+const ORPHAN_GRACE_MS = 30_000
+
+type TerminalEvent =
+  | { type: 'data'; data: string }
+  | { type: 'exit'; exitCode: number; signal: number }
+
+type Session = {
+  id: string
+  workspaceId: string
+  pty: IPty
+  buffer: string
+  listeners: Set<(event: TerminalEvent) => void>
+  orphanTimer: ReturnType<typeof setTimeout> | null
+  closed: boolean
+}
+
+const sessions = new Map<string, Session>()
+
+function boundedDimension(value: unknown, fallback: number, max: number): number {
+  const number = Number(value)
+  return Number.isFinite(number) ? Math.min(max, Math.max(1, Math.floor(number))) : fallback
+}
+
+function scheduleOrphanClose(session: Session): void {
+  if (session.closed || session.listeners.size > 0) return
+  if (session.orphanTimer) clearTimeout(session.orphanTimer)
+  session.orphanTimer = setTimeout(() => closeTerminalSession(session.id), ORPHAN_GRACE_MS)
+  session.orphanTimer.unref?.()
+}
+
+function requiredSession(id: string): Session {
+  const session = sessions.get(id)
+  if (!session || session.closed) throw new Error('Terminal session not found')
+  return session
+}
+
+export function createTerminalSession(input: {
+  workspaceId: string
+  cols?: number
+  rows?: number
+}): { id: string } {
+  const workspaceId = input.workspaceId.trim()
+  if (!workspaceId) throw new Error('A workspace is required')
+
+  const id = randomUUID()
+  const cwd = resolveWorkspacePath(workspaceId)
+  const pty = spawn(undefined, [], {
+    cwd,
+    cols: boundedDimension(input.cols, 80, 500),
+    rows: boundedDimension(input.rows, 24, 200),
+    name: 'xterm-256color',
+    env: { ...process.env, TERM: 'xterm-256color', COLORTERM: 'truecolor' },
+    shell: true,
+  })
+  const session: Session = {
+    id,
+    workspaceId,
+    pty,
+    buffer: '',
+    listeners: new Set(),
+    orphanTimer: null,
+    closed: false,
+  }
+  sessions.set(id, session)
+
+  pty.onData((chunk) => {
+    const data = typeof chunk === 'string' ? chunk : chunk.toString('utf8')
+    session.buffer = `${session.buffer}${data}`.slice(-MAX_BUFFER_CHARS)
+    for (const listener of session.listeners) listener({ type: 'data', data })
+  })
+  pty.onExit(({ exitCode, signal }) => {
+    session.closed = true
+    for (const listener of session.listeners) listener({ type: 'exit', exitCode, signal })
+    session.listeners.clear()
+    sessions.delete(id)
+  })
+  scheduleOrphanClose(session)
+  return { id }
+}
+
+export function writeTerminalSession(id: string, data: string): void {
+  if (data.length > 64_000) throw new Error('Terminal input is too large')
+  requiredSession(id).pty.write(data)
+}
+
+export function resizeTerminalSession(id: string, cols: unknown, rows: unknown): void {
+  requiredSession(id).pty.resize(boundedDimension(cols, 80, 500), boundedDimension(rows, 24, 200))
+}
+
+export function closeTerminalSession(id: string): void {
+  const session = sessions.get(id)
+  if (!session) return
+  session.closed = true
+  if (session.orphanTimer) clearTimeout(session.orphanTimer)
+  session.listeners.clear()
+  sessions.delete(id)
+  session.pty.close()
+}
+
+export function subscribeTerminalSession(
+  id: string,
+  listener: (event: TerminalEvent) => void,
+): { buffer: string; unsubscribe: () => void } {
+  const session = requiredSession(id)
+  if (session.orphanTimer) clearTimeout(session.orphanTimer)
+  session.orphanTimer = null
+  session.listeners.add(listener)
+  return {
+    buffer: session.buffer,
+    unsubscribe: () => {
+      session.listeners.delete(listener)
+      scheduleOrphanClose(session)
+    },
+  }
+}

--- a/src/server/terminalStream.ts
+++ b/src/server/terminalStream.ts
@@ -1,0 +1,42 @@
+import { subscribeTerminalSession } from './terminalSessions.ts'
+
+const encoder = new TextEncoder()
+
+function encode(data: unknown): Uint8Array {
+  return encoder.encode(`data: ${JSON.stringify(data)}\n\n`)
+}
+
+export function createTerminalStream(sessionId: string, signal: AbortSignal): ReadableStream {
+  let unsubscribe = () => {}
+  return new ReadableStream({
+    start(controller) {
+      const subscription = subscribeTerminalSession(sessionId, (event) => {
+        try {
+          controller.enqueue(encode(event))
+          if (event.type === 'exit') controller.close()
+        } catch {
+          unsubscribe()
+        }
+      })
+      unsubscribe = subscription.unsubscribe
+      if (subscription.buffer)
+        controller.enqueue(encode({ type: 'data', data: subscription.buffer }))
+
+      signal.addEventListener(
+        'abort',
+        () => {
+          unsubscribe()
+          try {
+            controller.close()
+          } catch {
+            // The PTY exit may already have closed the stream.
+          }
+        },
+        { once: true },
+      )
+    },
+    cancel() {
+      unsubscribe()
+    },
+  })
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,3 +1,4 @@
+@import '@xterm/xterm/css/xterm.css';
 @import 'tailwindcss';
 
 * {


### PR DESCRIPTION
## Summary
- Add an interactive Zigpty terminal to each run workspace.
- Keep shell input, output, resizing, and cleanup synchronized through local terminal sessions.
- Render full terminal behavior with xterm while preserving the existing resizable drawer.

Closes #66

## Test plan
- [ ] Open a run, toggle the terminal, and confirm the shell starts in that run’s active workspace.
- [ ] Run a command and switch Git branches; confirm the same checkout changes in VS Code or Cursor.
- [ ] Resize the terminal drawer and browser window; confirm the shell redraws at the new dimensions.
- [ ] Close and reopen the terminal; confirm the old session exits cleanly and a fresh shell starts.