### PR TITLE
fix(runs): preserve chat workspaces and accurate outcomes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -193,7 +193,7 @@ Neither hook may open an `EventSource` of its own.
 | An Apple client (iOS, macOS) | `clients/apple/OpenRunKit/` — `Generated.swift` is generated, everything else is hand-written |
 | Run/turn lifecycle, spawning a CLI, streaming stdout | `server/executor.ts` |
 | Per-CLI differences: headless invocation, session id, resume, model/effort flags | `server/resume.ts`, `lib/models.ts` |
-| Adopting a chat started in the CLI itself | `lib/nativeSessions.ts` + `server/nativeSessions.ts` (find them), `lib/nativeTranscript.ts` + `server/nativeTranscript.ts` (read one in full), `server/nativeImport.ts` (write it into a run), `executor.adoptNativeChat` (adopt without prompting); picker in `components/NativeSessionMenu.tsx` |
+| Adopting a chat started in the CLI itself | `lib/nativeSessions.ts` + `server/nativeSessions.ts` (find them), `lib/nativeTranscript.ts` + `server/nativeTranscript.ts` (read one in full), `server/nativeImport.ts` (write it into a run), `executor.adoptNativeChat` (adopt without prompting); picker in `components/ComposerControls.tsx`. Automations resume saved chats in their existing workspace. |
 | Continuing a chat on another runtime (Claude ⇄ Codex handoff) | `lib/runtimeSwitch.ts` (the rules), `lib/handoffPrompt.ts` (what the new agent is told), `executor.sendFollowUp` (the switch); picker + one-time note in `components/Chat.tsx` |
 | Which models a picker offers | `server/modelCatalog.ts` (cache + refresh), `lib/modelDiscovery.ts` (per-CLI parsers); `lib/models.ts` is only the fallback seed |
 | Hiding models from the picker | `visibleModels` / `hiddenModelsIn` / `toggleHiddenModel` in `lib/models.ts`; stored as `hiddenModels` in `lib/pickerPrefs.ts` (localStorage, display-only — the server never reads it) |
@@ -206,7 +206,7 @@ Neither hook may open an `EventSource` of its own.
 | AI SDK UI Message Stream projection (read-only) | `lib/uiMessageStream.ts`, `routes/api/runs/$runId/ui-stream.ts` |
 | Schema, migrations, seeded runtimes, `~/.openrun` paths | `server/db.ts` |
 | Cron arming | `server/scheduler.ts`; validation/labels in `lib/cron.ts`, `lib/scheduleHealth.ts` |
-| Projects, shared-checkout chats, worktrees, `resolveWorkspacePath`, `assertWorkspaceFree` | `server/workspaces.ts`; `/runs/new` offers the primary checkout only for interactive chats, while automations remain worktree-only |
+| Projects, shared-checkout chats, worktrees, `resolveWorkspacePath`, `assertWorkspaceFree` | `server/workspaces.ts`; externally-created Git worktrees are registered as user-owned workspaces and are never reset or removed by Open Run. |
 | Is a workspace physically fit to run in (exists, right worktree, right branch, clean)? | `lib/workspaceHealth.ts` (the codes + wording), `server/workspaceHealth.ts` (inspection, quarantine, restore) |
 | Why a scheduled / webhook fire is refused (isolation, contamination, `gh` preflight) | `lib/unattendedGate.ts` (the rules), `server/unattendedPreflight.ts` (the lookups); called from `scheduler.refusal`, `runQueue.drainWorkspace`, `integrations/dispatcher.ts`, `core.setTaskEnabled` / `upsertTask` |
 | Diffs, commit/push/branch/PR, base snapshots | `server/git.ts`; UI in `components/GitActions.tsx`, `components/DiffPanel.tsx`, `lib/diff.ts` |

--- a/changelog.d/automation-resume-chat.md
+++ b/changelog.d/automation-resume-chat.md
@@ -1,0 +1,3 @@
+- You no longer need another worktree to continue a saved CLI chat. Interactive,
+  manual, and scheduled runs use the chat's existing workspace, while webhook
+  deliveries still start clean in their own worktree.

--- a/changelog.d/keep-machine-awake-during-runs.md
+++ b/changelog.d/keep-machine-awake-during-runs.md
@@ -1,0 +1,4 @@
+- Scheduled runs no longer die at their timeout because the Mac went back to
+  sleep. Open Run holds a wake assertion for as long as an agent is running, so
+  a 30-minute budget buys 30 minutes of work instead of a handful of dark-wake
+  seconds.

--- a/changelog.d/run-outcome-regressions.md
+++ b/changelog.d/run-outcome-regressions.md
@@ -1,0 +1,4 @@
+- You no longer see a successful run marked failed because it read an old GitHub
+  authentication error from a log or source file.
+- Temporary webhook checkouts no longer appear as user-owned workspaces, and
+  scheduled automation readiness now reflects the same checks used when it fires.

--- a/src/components/TaskForm.tsx
+++ b/src/components/TaskForm.tsx
@@ -19,7 +19,12 @@ import { useClickOutside } from '../hooks/useClickOutside'
 import { createPortal } from 'react-dom'
 import { toast } from './toast'
 import { invalidCronMessage, isValidCron } from '../lib/cron'
-import { nativeResumeKindFor } from '../lib/nativeSessions'
+import {
+  nativeResumeKindFor,
+  NATIVE_RESUME_DEFAULT_PROMPT,
+  type NativeSession,
+  type NativeSessionGroup,
+} from '../lib/nativeSessions'
 import { DEFAULT_RUN_TIMEOUT_MS } from '../lib/runBudget'
 import { MAX_REPAIR_ATTEMPTS } from '../lib/verdict'
 import {
@@ -41,6 +46,7 @@ import {
   useProjectBranches,
   usePlugins,
   useSlashCommands,
+  useNativeSessions,
 } from '../lib/queries'
 import {
   applyPluginMention,
@@ -968,6 +974,7 @@ export function TaskForm({
   const { data: allWorkspaces } = useWorkspaces()
   const { data: projectWorkspaces } = useWorkspaces(projectId || undefined)
   const { data: gitBranches } = useProjectBranches(projectId || undefined)
+  const nativeQuery = useNativeSessions({ allWorkspaces: true }, { enabled: true })
 
   useEffect(() => {
     if (!v.workspaceId || projectId) return
@@ -1087,6 +1094,25 @@ export function TaskForm({
     })
     remember({ runtimeId: id })
   }
+  const pickNativeSession = (session: NativeSession, group: NativeSessionGroup) => {
+    seededRuntimeRef.current = null
+    setDirty(true)
+    setNativeError(null)
+    if (session.projectId) setProjectId(session.projectId)
+    setV((prev) => ({
+      ...prev,
+      workspaceId: session.workspaceId ?? prev.workspaceId,
+      runtimeId: group.runtimeId,
+      resumeSessionId: session.sessionId,
+      resumeSessionLabel: session.title,
+      prompt: prev.prompt.trim() ? prev.prompt : NATIVE_RESUME_DEFAULT_PROMPT,
+    }))
+    remember({ runtimeId: group.runtimeId })
+  }
+  const clearResume = () => {
+    set('resumeSessionId', '')
+    set('resumeSessionLabel', '')
+  }
   const changeModel = (slug: string) => {
     setDirty(true)
     setModel(slug)
@@ -1119,6 +1145,18 @@ export function TaskForm({
     promptRef.current?.focus()
   }
 
+  const runtimeSessions = v.workspaceId
+    ? {
+        workspaceId: v.workspaceId,
+        groups: nativeQuery.data?.groups ?? [],
+        resumeSessionId: v.resumeSessionId ?? '',
+        resumeSessionLabel: v.resumeSessionLabel ?? '',
+        onOpen: () => void nativeQuery.refetch(),
+        onSelectNew: clearResume,
+        onSelect: pickNativeSession,
+      }
+    : undefined
+
   const selectProject = (pid: string) => {
     setProjectId(pid)
     set('baseRef', '')
@@ -1127,18 +1165,14 @@ export function TaskForm({
       set('workspaceId', '')
       return
     }
-    const eligible = (allWorkspaces ?? []).filter(
-      (workspace) => workspace.projectId === pid && workspace.kind === 'main',
-    )
+    const eligible = (allWorkspaces ?? []).filter((workspace) => workspace.projectId === pid)
     set('workspaceId', pickDefaultWorkspace(eligible)?.id ?? '')
   }
 
   const selectedProject = projects?.find((project) => project.id === projectId)
   useEffect(() => {
     if (!projectId || v.workspaceId) return
-    const picked = pickDefaultWorkspace(
-      (projectWorkspaces ?? []).filter((workspace) => workspace.kind === 'main'),
-    )
+    const picked = pickDefaultWorkspace(projectWorkspaces ?? [])
     if (picked) {
       setV((prev) => ({ ...prev, workspaceId: picked.id }))
     }
@@ -1225,7 +1259,9 @@ export function TaskForm({
   const workspaceChanged = Boolean(
     initial?.id && v.workspaceId && v.workspaceId !== initial.workspaceId,
   )
-  const selectedBranch = v.baseRef || selectedProject?.defaultBranch
+  const selectedBranch = v.webhookIntegrationId
+    ? v.baseRef || selectedProject?.defaultBranch
+    : selectedWorkspace?.branch
   // Checks live on the project, so how many exist depends on which repository
   // the automation targets — worth saying out loud here, because with none the
   // "verified" outcome is unreachable no matter what this form is set to.
@@ -1314,18 +1350,40 @@ export function TaskForm({
             |
           </span>
 
-          <BaseRefPicker
-            branches={gitBranches ?? []}
-            value={v.baseRef ?? ''}
-            disabled={!projectId || Boolean(workspaceChangeBlockedReason)}
-            {...(workspaceChangeBlockedReason
-              ? { disabledReason: workspaceChangeBlockedReason }
-              : {})}
-            {...(selectedProject?.defaultBranch
-              ? { defaultBranch: selectedProject.defaultBranch }
-              : {})}
-            onChange={(ref) => set('baseRef', ref)}
-          />
+          {v.webhookIntegrationId ? (
+            <BaseRefPicker
+              branches={gitBranches ?? []}
+              value={v.baseRef ?? ''}
+              disabled={!projectId || Boolean(workspaceChangeBlockedReason)}
+              {...(workspaceChangeBlockedReason
+                ? { disabledReason: workspaceChangeBlockedReason }
+                : {})}
+              {...(selectedProject?.defaultBranch
+                ? { defaultBranch: selectedProject.defaultBranch }
+                : {})}
+              onChange={(ref) => set('baseRef', ref)}
+            />
+          ) : (
+            <select
+              aria-label="Workspace"
+              className={inputClass}
+              value={v.workspaceId}
+              disabled={!projectId || Boolean(workspaceChangeBlockedReason)}
+              onChange={(event) => {
+                set('workspaceId', event.target.value)
+                clearResume()
+              }}
+            >
+              <option value="">Choose a workspace…</option>
+              {(projectWorkspaces ?? [])
+                .filter((workspace) => workspace.status !== 'archived')
+                .map((workspace) => (
+                  <option key={workspace.id} value={workspace.id}>
+                    {workspace.name} · {workspace.branch}
+                  </option>
+                ))}
+            </select>
+          )}
         </div>
         {nativeError ? <p className="mt-2 text-[12px] text-rose-300">{nativeError}</p> : null}
         {workspaceError ? (
@@ -1338,15 +1396,8 @@ export function TaskForm({
           </p>
         ) : null}
         {v.resumeSessionId ? (
-          <button
-            type="button"
-            className="mt-2 text-ui-sm text-warn"
-            onClick={() => {
-              set('resumeSessionId', '')
-              set('resumeSessionLabel', '')
-            }}
-          >
-            Clear saved chat to use isolated runs
+          <button type="button" className="mt-2 text-ui-sm text-warn" onClick={clearResume}>
+            Use a new conversation
           </button>
         ) : null}
       </header>
@@ -1463,24 +1514,16 @@ export function TaskForm({
                     onChange={changeEffort}
                   />
                 </>
-              ) : runtimes && runtimes.length > 0 ? (
-                <RuntimePicker
-                  runtimes={runtimes}
-                  runtimeId={v.runtimeId}
-                  align="start"
-                  initiallyOpen={demoPreview}
-                  keepOpen={demoPreview}
-                  onChange={changeRuntimeId}
-                />
               ) : null}
-              {runtimes && runtimes.length > 1 && models.length > 0 ? (
-                <div className="ml-auto">
+              {runtimes && runtimes.length > 0 ? (
+                <div className={models.length > 0 ? 'ml-auto' : undefined}>
                   <RuntimePicker
                     runtimes={runtimes}
                     runtimeId={v.runtimeId}
-                    align="end"
+                    align={models.length > 0 ? 'end' : 'start'}
                     initiallyOpen={demoPreview}
                     keepOpen={demoPreview}
+                    {...(runtimeSessions ? { sessions: runtimeSessions } : {})}
                     onChange={changeRuntimeId}
                   />
                 </div>
@@ -1825,7 +1868,8 @@ function VerificationSection({
 
       <div className="border-t border-[var(--border-quaternary)] pt-3">
         <p className="text-ui-sm text-tier-tertiary">
-          Every automation run is isolated from your project checkout and other runs.
+          Scheduled and manual runs continue in the selected workspace. Webhook deliveries start
+          from the configured base in a fresh worktree.
         </p>
 
         <label className="mt-3 flex cursor-pointer items-center gap-2">

--- a/src/components/WorkspacePicker.tsx
+++ b/src/components/WorkspacePicker.tsx
@@ -18,10 +18,9 @@ export function WorkspacePicker({
   const [managing, setManaging] = useState(false)
   useEffect(() => {
     if (!projectId || !workspaces) return
-    const main = workspaces.find(
-      (w) => w.projectId === projectId && w.kind === 'main' && w.status === 'ready',
-    )
-    if (main && workspaceId !== main.id) onChange({ projectId, workspaceId: main.id })
+    if (workspaces.some((workspace) => workspace.id === workspaceId)) return
+    const selected = workspaces.find((w) => w.projectId === projectId && w.status === 'ready')
+    if (selected) onChange({ projectId, workspaceId: selected.id })
   }, [projectId, workspaceId, workspaces, onChange])
   return (
     <div>
@@ -40,7 +39,7 @@ export function WorkspacePicker({
         </select>
       </Field>
       <p className="mt-2 text-ui-sm text-tier-tertiary">
-        Automations get a clean checkout for each run, based on the project's default branch.
+        Scheduled runs use this checkout. Webhook deliveries get a fresh worktree from the base.
       </p>
       <button
         type="button"

--- a/src/hooks/useNewRunDraft.ts
+++ b/src/hooks/useNewRunDraft.ts
@@ -93,7 +93,7 @@ export function useNewRunDraft(
 
   const project = projects?.find((row) => row.id === projectId)
   const workspaces = useMemo(
-    () => (allWorkspaces ?? []).filter((w) => w.kind === 'main' && w.status !== 'archived'),
+    () => (allWorkspaces ?? []).filter((w) => w.status !== 'archived'),
     [allWorkspaces],
   )
 

--- a/src/lib/executionWorkspace.test.ts
+++ b/src/lib/executionWorkspace.test.ts
@@ -1,0 +1,18 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+import { resumesSavedSession, usesFreshExecution } from './executionWorkspace.ts'
+
+describe('execution workspace policy', () => {
+  it('reuses selected workspaces for interactive, manual, and scheduled runs', () => {
+    assert.equal(usesFreshExecution('interactive'), false)
+    assert.equal(usesFreshExecution('manual'), false)
+    assert.equal(usesFreshExecution('schedule'), false)
+  })
+
+  it('isolates webhook deliveries and starts their conversation fresh', () => {
+    assert.equal(usesFreshExecution('webhook'), true)
+    assert.equal(resumesSavedSession('webhook'), false)
+    assert.equal(resumesSavedSession('manual'), true)
+    assert.equal(resumesSavedSession('schedule'), true)
+  })
+})

--- a/src/lib/executionWorkspace.ts
+++ b/src/lib/executionWorkspace.ts
@@ -1,0 +1,13 @@
+/** Browser-safe placement policy shared by executor and unattended gates. */
+
+export type AutomationTrigger = 'manual' | 'schedule' | 'webhook'
+
+/** Webhook deliveries alone get a clean, Open Run-owned execution worktree. */
+export function usesFreshExecution(trigger: string): boolean {
+  return trigger === 'webhook'
+}
+
+/** A saved native conversation belongs to its existing workspace. */
+export function resumesSavedSession(trigger: AutomationTrigger): boolean {
+  return !usesFreshExecution(trigger)
+}

--- a/src/lib/ghOutcome.test.ts
+++ b/src/lib/ghOutcome.test.ts
@@ -1,6 +1,6 @@
 import { test } from 'node:test'
 import assert from 'node:assert/strict'
-import { detectGhFailure } from './ghOutcome.ts'
+import { detectGhFailure, detectGhFailureInEvents } from './ghOutcome.ts'
 
 test('detects unauthenticated gh', () => {
   const out = detectGhFailure(
@@ -29,4 +29,26 @@ test('clean success output is not flagged', () => {
 
 test('empty output is not flagged', () => {
   assert.equal(detectGhFailure('').failed, false)
+})
+
+test('authentication instructions alone are not a failure', () => {
+  assert.equal(detectGhFailure('Use gh auth login to connect your account.').failed, false)
+})
+
+test('successful diagnostic output and quoted old failures do not fail the turn', () => {
+  const content = 'You are not logged into any GitHub hosts. Run gh auth login to authenticate.'
+  for (const kind of ['assistant', 'tool_start', 'tool_result'] as const) {
+    assert.equal(
+      detectGhFailureInEvents([{ kind, payload: JSON.stringify({ status: 'completed', content }) }])
+        .failed,
+      false,
+    )
+  }
+  assert.equal(
+    detectGhFailureInEvents([
+      { kind: 'tool_result', payload: JSON.stringify({ status: 'failed', content }) },
+    ]).failed,
+    true,
+  )
+  assert.equal(detectGhFailureInEvents([{ kind: 'tool_result', payload: '{}' }]).failed, false)
 })

--- a/src/lib/ghOutcome.ts
+++ b/src/lib/ghOutcome.ts
@@ -7,10 +7,11 @@
  * `changelog.d/05-github-tool-calls-spike.md`; core behavior in
  * `changelog.d/05-github-tool-calls-core.md`.
  *
- * This is a best-effort, browser-safe string scan over combined stdout+stderr.
- * It only matches phrases `gh`/`git` emit on real failures, so a passing run
- * that merely mentions "gh auth login" in prose is unlikely to trip it.
+ * Structured transcripts scan failed tool results only. Combined stdout and
+ * stderr remain a best-effort fallback for runtimes without structured events.
  */
+
+import type { TurnEventRow } from './turnEvents.ts'
 
 export type GhFailure = {
   failed: boolean
@@ -23,7 +24,7 @@ const SIGNATURES: Array<{ pattern: RegExp; reason: string }> = [
     reason: 'gh is not authenticated (run: gh auth login)',
   },
   {
-    pattern: /gh auth login|To authenticate, please run/i,
+    pattern: /To authenticate, please run/i,
     reason: 'gh asked the user to authenticate (gh auth login)',
   },
   {
@@ -44,6 +45,24 @@ export function detectGhFailure(text: string): GhFailure {
   if (!text) return { failed: false }
   for (const { pattern, reason } of SIGNATURES) {
     if (pattern.test(text)) return { failed: true, reason }
+  }
+  return { failed: false }
+}
+
+/** Inspect failed commands only; source files and old logs are not outcomes. */
+export function detectGhFailureInEvents(
+  events: Pick<TurnEventRow, 'kind' | 'payload'>[],
+): GhFailure {
+  for (const event of events) {
+    if (event.kind !== 'tool_result') continue
+    try {
+      const payload = JSON.parse(event.payload)
+      if (payload.status !== 'failed') continue
+      const failure = detectGhFailure(payload.content ?? payload.result ?? '')
+      if (failure.failed) return failure
+    } catch {
+      // Historical or malformed payloads do not establish a command failure.
+    }
   }
   return { failed: false }
 }

--- a/src/lib/unattendedGate.test.ts
+++ b/src/lib/unattendedGate.test.ts
@@ -3,7 +3,6 @@ import { describe, it } from 'node:test'
 import {
   canRunUnattended,
   requiresGhAuth,
-  sharedCheckoutMessage,
   unattendedBlockedReason,
   workspaceOwnerMessage,
   type UnattendedGateInput,
@@ -32,27 +31,42 @@ function input(over: Partial<UnattendedGateInput> = {}): UnattendedGateInput {
 }
 
 describe('unattendedGate', () => {
+  it('a saved conversation may retain edits but cannot bypass quarantine or a missing directory', () => {
+    for (const code of ['dirty', 'branch-drift', 'detached'] as const) {
+      assert.equal(
+        unattendedBlockedReason(input({ resumeSessionId: 'saved', health: { ...healthy, code } })),
+        null,
+      )
+    }
+    for (const code of ['blocked', 'missing', 'not-a-worktree'] as const) {
+      assert.ok(
+        unattendedBlockedReason(input({ resumeSessionId: 'saved', health: { ...healthy, code } })),
+      )
+    }
+  })
   it('a clean isolated worktree may fire', () => {
     assert.equal(unattendedBlockedReason(input()), null)
     assert.equal(canRunUnattended(input()), true)
   })
 
-  it('the shared main checkout is refused, and named as the reason', () => {
-    assert.equal(unattendedBlockedReason(input({ workspaceKind: 'main' })), sharedCheckoutMessage())
+  it('a scheduled run may use the shared main checkout', () => {
+    assert.equal(unattendedBlockedReason(input({ workspaceKind: 'main' })), null)
   })
 
-  it('isolation is an opt-out, not a law', () => {
-    assert.equal(
-      unattendedBlockedReason(input({ workspaceKind: 'main', requireIsolation: false })),
-      null,
-    )
-  })
-
-  it('isolation outranks health — a shared checkout makes health meaningless', () => {
+  it('a dirty shared checkout is refused for a scheduled run', () => {
     const reason = unattendedBlockedReason(
       input({ workspaceKind: 'main', health: { ...healthy, code: 'dirty', dirty: true } }),
     )
-    assert.equal(reason, sharedCheckoutMessage())
+    assert.match(reason ?? '', /uncommitted changes/i)
+  })
+
+  it('a webhook execution ignores source-checkout contamination', () => {
+    assert.equal(
+      unattendedBlockedReason(
+        input({ freshExecution: true, health: { ...healthy, code: 'dirty', dirty: true } }),
+      ),
+      null,
+    )
   })
 
   it('a contaminated worktree is refused even when isolated', () => {

--- a/src/lib/unattendedGate.ts
+++ b/src/lib/unattendedGate.ts
@@ -7,10 +7,9 @@
  * are what separate an AFK-safe automation from one that merely started on
  * time:
  *
- * 1. **Isolation** — unattended coding happens in an app-managed worktree on
- *    its own branch, never in the checkout the user's editor is sitting in.
- *    Sharing that checkout is what lets one automation's branch switch and
- *    broken build leak into every later automation.
+ * 1. **Serialization** — scheduled runs reuse their selected checkout and the
+ *    workspace queue keeps one writer there at a time. Webhooks receive a
+ *    fresh execution worktree.
  * 2. **Health** — the worktree must physically exist, be the right worktree,
  *    be on its configured branch, and be clean (see `workspaceHealth.ts`).
  * 3. **Capability preflight** — an automation that is going to reach for
@@ -26,6 +25,7 @@ import { workspaceHealthBlockedReason, type WorkspaceHealth } from './workspaceH
 export type UnattendedGateInput = {
   /** The executor creates a fresh checkout from a resolved commit. */
   freshExecution?: boolean
+  resumeSessionId?: string
   /** 'main' is the user's own checkout; 'worktree' is app-managed and disposable. */
   workspaceKind: string
   /** Task opt-out. False lets an automation deliberately run in the main checkout. */
@@ -38,7 +38,7 @@ export type UnattendedGateInput = {
   ghAuthenticated: boolean
 }
 
-/** Developer-facing error when an unattended run targets the shared checkout. */
+/** Legacy wording retained for old clients that may still display the action. */
 export function sharedCheckoutMessage(): string {
   return "Unattended runs are not allowed in the main checkout — it is shared with your editor and with every other automation, so one run's branch switch and leftover edits become the next run's starting point. Give this automation its own worktree, or turn off workspace isolation for it."
 }
@@ -66,13 +66,16 @@ export function requiresGhAuth(input: { canOpenPrs: boolean; requireGhAuth: bool
 
 /**
  * Reason an unattended fire would be unsafe, or `null` when it may proceed.
- * Isolation first: a shared checkout makes every other signal untrustworthy.
+ * Webhook isolation is represented by `freshExecution`; scheduled runs are
+ * serialized by the workspace queue before reaching this gate.
  */
 export function unattendedBlockedReason(input: UnattendedGateInput): string | null {
-  if (!input.freshExecution && input.requireIsolation && input.workspaceKind === 'main') {
-    return sharedCheckoutMessage()
-  }
-  const health = workspaceHealthBlockedReason(input.health, { unattended: !input.freshExecution })
+  const continuing = !input.freshExecution && Boolean(input.resumeSessionId?.trim())
+  const inspected =
+    continuing && input.health && ['dirty', 'branch-drift', 'detached'].includes(input.health.code)
+      ? { ...input.health, code: 'ok' as const }
+      : input.health
+  const health = workspaceHealthBlockedReason(inspected, { unattended: !input.freshExecution })
   if (health) return health
   if (input.requiresGh && !(input.ghInstalled && input.ghAuthenticated)) {
     return ghPreflightMessage(input.ghInstalled)

--- a/src/server/afkSafety.test.ts
+++ b/src/server/afkSafety.test.ts
@@ -283,7 +283,7 @@ describe('AFK safety core boundaries', () => {
     )
   })
 
-  it('commits what a scheduled run left behind so the next fire is not refused', async () => {
+  it('keeps a scheduled run in its selected workspace', async () => {
     const db = getDb()
     // A runtime that actually writes a file, the way a real agent would.
     db.prepare("UPDATE runtimes SET argsTemplate = ? WHERE id = 'afk-runtime'").run(
@@ -304,30 +304,16 @@ describe('AFK safety core boundaries', () => {
     const firstId = executor.runTask(row, runtime, 'schedule')
     assert.equal(await waitForTerminal(firstId), 'success')
 
-    // The agent's file is committed on the worktree branch, not left dirty.
+    // The agent's file remains in the selected checkout for the user to review.
     const status = execFileSync('git', ['status', '--porcelain'], {
       cwd: worktree,
       encoding: 'utf8',
     }).trim()
-    assert.equal(status, '', `expected a clean worktree, got:\n${status}`)
-    const subject = execFileSync(
-      'git',
-      ['log', '-1', '--format=%s', core.getRun(firstId)!.headBranch],
-      {
-        cwd: worktree,
-        encoding: 'utf8',
-      },
-    ).trim()
-    assert.match(subject, /Nightly output \(verified\)/)
-
-    // …which is what lets the *next* scheduled fire through. Before this, the
-    // dirty tree refused it with "the workspace has uncommitted changes".
-    assert.equal(unattendedRefusal(row, runtime), null)
-    const secondId = executor.runTask(row, runtime, 'schedule')
-    assert.equal(await waitForTerminal(secondId), 'success')
+    assert.match(status, /agent-output\.txt/)
+    assert.equal(core.getRun(firstId)!.cwd, worktree)
   })
 
-  it('leaves the project checkout unchanged for every scheduled entry point', async () => {
+  it('runs scheduled entry points in the selected project checkout', async () => {
     // `upsertTask` refuses the primary checkout outright, so drive the
     // unattended path directly: the guard has to hold for any scheduled run,
     // not only the ones the task form can produce.
@@ -358,7 +344,8 @@ describe('AFK safety core boundaries', () => {
       cwd: repo,
       encoding: 'utf8',
     }).trim()
-    assert.equal(status, '')
+    assert.match(status, /main-output\.txt/)
+    assert.equal(core.getRun(runId)!.cwd, repo)
   })
 
   it('accepts a project checkout as an automation target', () => {

--- a/src/server/core.ts
+++ b/src/server/core.ts
@@ -832,16 +832,15 @@ function decorate(
     requireGhAuth: task.requireGhAuth === 1,
   })
   const unattendedOwner = workspace ? getUnattendedWorkspaceOwner(workspace.id, task.id) : undefined
-  const baseBlocked = task.resumeSessionId
-    ? 'Automations start a fresh conversation in an isolated checkout. Clear the saved chat before running.'
-    : automationBaseRefusal(task.workspaceId, task.baseRef)
+  const baseBlocked = automationBaseRefusal(task.workspaceId, task.baseRef)
   const unattendedBlocked =
     baseBlocked ||
     (unattendedOwner
       ? workspaceOwnerMessage(unattendedOwner.name)
       : workspace
         ? unattendedBlockedReason({
-            freshExecution: true,
+            freshExecution: Boolean(task.webhookIntegrationId.trim()),
+            resumeSessionId: task.resumeSessionId,
             workspaceKind: workspace.kind,
             requireIsolation: task.requireIsolation === 1,
             health,
@@ -1129,6 +1128,14 @@ export function upsertTask(input: TaskInput): TaskWithMeta {
   }
 
   const baseRef = input.baseRef?.trim() ?? existingRow?.baseRef ?? ''
+  const resumeSessionId =
+    input.resumeSessionId !== undefined
+      ? input.resumeSessionId.trim()
+      : (existingRow?.resumeSessionId ?? '')
+  const resumeSessionLabel =
+    input.resumeSessionLabel !== undefined
+      ? input.resumeSessionLabel.trim()
+      : (existingRow?.resumeSessionLabel ?? '')
   const baseRefusal = automationBaseRefusal(workspaceId, baseRef)
   if (baseRefusal) throw new Error(baseRefusal)
 
@@ -1187,19 +1194,7 @@ export function upsertTask(input: TaskInput): TaskWithMeta {
       ? assertRunTimeoutMinutes(input.timeoutMinutes)
       : (existingRow?.timeoutMs ?? 0)
 
-  const resumeSessionId =
-    input.resumeSessionId !== undefined
-      ? input.resumeSessionId.trim()
-      : (existingRow?.resumeSessionId ?? '')
-  const resumeSessionLabel =
-    input.resumeSessionLabel !== undefined
-      ? input.resumeSessionLabel.trim()
-      : (existingRow?.resumeSessionLabel ?? '')
-  if (resumeSessionId)
-    throw new Error(
-      'Automations start a fresh conversation in an isolated checkout. Clear the saved chat before running.',
-    )
-  const requireIsolation = 1
+  const requireIsolation = 0
   const requireGhAuth =
     input.requireGhAuth !== undefined
       ? input.requireGhAuth
@@ -1236,7 +1231,8 @@ export function upsertTask(input: TaskInput): TaskWithMeta {
     const runtime = getRuntime(input.runtimeId)
     if (checked && runtime) {
       const refused = unattendedRefusalFor({
-        task: { requireIsolation, requireGhAuth, baseRef },
+        task: { requireIsolation, requireGhAuth, baseRef, resumeSessionId },
+        trigger: webhookIntegrationId ? 'webhook' : 'schedule',
         runtime,
         workspace: checked.workspace,
         health: checked.health,
@@ -1376,6 +1372,7 @@ export function setTaskEnabled(taskId: string, enabled: boolean) {
       const refused = runtime
         ? unattendedRefusalFor({
             task,
+            trigger: task.webhookIntegrationId.trim() ? 'webhook' : 'schedule',
             runtime,
             workspace: checked.workspace,
             health: checked.health,
@@ -1622,7 +1619,7 @@ export type StartRunWorkspaceOption = {
   projectName: string
   name: string
   branch: string
-  kind: 'main' | 'worktree'
+  kind: 'main' | 'worktree' | 'external'
   status: 'creating' | 'ready' | 'error' | 'archived'
   /** Set while another run holds this worktree. */
   activeRunId: string | null
@@ -1647,7 +1644,7 @@ export function startRunOptions(): {
   runtimes: StartRunRuntimeOption[]
 } {
   const workspaces = listWorkspaces()
-    .filter((workspace) => workspace.kind === 'main' && workspace.status !== 'archived')
+    .filter((workspace) => workspace.status !== 'archived')
     .map((workspace) => {
       // Read, never repair: `decorate` documents why drawing a list must not
       // demote a row, and the same holds here.

--- a/src/server/db.ts
+++ b/src/server/db.ts
@@ -395,7 +395,7 @@ export type WorkspaceRow = {
   /** Absolute path to the worktree (or the repo root itself when kind='main'). */
   path: string
   /** 'main' = the project's primary checkout (registered projects only); 'worktree' = an app-managed worktree. */
-  kind: 'main' | 'worktree'
+  kind: 'main' | 'worktree' | 'external'
   status: 'creating' | 'ready' | 'error' | 'archived'
   setupLog: string
   setupExitCode: number | null

--- a/src/server/executor.ts
+++ b/src/server/executor.ts
@@ -66,6 +66,7 @@ import {
   unattendedCommitFailedMessage,
   unattendedCommitMessage,
 } from '../lib/unattendedCommit.ts'
+import { resumesSavedSession, usesFreshExecution } from '../lib/executionWorkspace.ts'
 import { isMessageId } from '../lib/messageId.ts'
 import { DEFAULT_RUNTIME_MODE, parseRuntimeMode, type RuntimeMode } from '../lib/runtimeMode'
 import type { TurnEventPayload } from '../lib/turnEvents'
@@ -87,7 +88,7 @@ import { buildHandoffPrompt, handoffSystemNote, type HandoffMessage } from '../l
 import { isRuntimeSwitch, resolveSwitchMode, resolveSwitchModel } from '../lib/runtimeSwitch.ts'
 import { cachedModelsForBin } from './modelCatalog.ts'
 import { describeEffectiveTurnSettings } from '../lib/runSettingsDebug.ts'
-import { detectGhFailure } from '../lib/ghOutcome'
+import { detectGhFailure, detectGhFailureInEvents } from '../lib/ghOutcome'
 import { assertRuntimeOnPath } from './runtimePath'
 import { nativeSessionExists } from './nativeSessions'
 import { importNativeTranscript } from './nativeImport'
@@ -116,6 +117,7 @@ import {
   type FailedCheckSummary,
   type RunVerdict,
 } from '../lib/verdict'
+import { holdWakeLock, type WakeLock } from './wakeLock'
 import {
   agentSpawnOptions,
   isPidAlive,
@@ -338,11 +340,7 @@ export function startRun(input: StartRunInput): string {
   // the old cwd-or-process.cwd() fallback untouched. Planner stores a target
   // workspaceId for install cards but does not lock or chdir into it.
   const isolated =
-    (input.isolated === true ||
-      Boolean(input.taskId) ||
-      input.trigger === 'schedule' ||
-      input.trigger === 'webhook') &&
-    input.trigger !== 'planner'
+    (input.isolated === true || usesFreshExecution(input.trigger)) && input.trigger !== 'planner'
   const lockWorkspace = input.lockWorkspace !== false && !isolated
   let cwd: string
   if (input.workspaceId && input.workspaceId.trim().length > 0 && lockWorkspace) {
@@ -361,10 +359,6 @@ export function startRun(input: StartRunInput): string {
   const kind = runtimeKind(input.runtime.bin)
   const resumeSessionId = input.resumeSessionId?.trim() ?? ''
   const resumeKind = nativeResumeKindFor(input.runtime)
-  if (isolated && resumeSessionId)
-    throw new Error(
-      'Automations start a fresh conversation in an isolated checkout. Clear the saved chat before running.',
-    )
   if (resumeSessionId) {
     if (!resumeKind) {
       throw new Error(nativeResumeNotSupportedMessage())
@@ -1044,6 +1038,7 @@ function spawnTurn(input: {
 
   liveMap().set(runId, { child })
   db.prepare('UPDATE runs SET pid = ? WHERE id = ?').run(child.pid ?? null, runId)
+  const wakeLock = holdWakeLock(child.pid, timeoutMs)
 
   const appendRunStdout = db.prepare('UPDATE runs SET stdout = stdout || ? WHERE id = ?')
   const appendRunStderr = db.prepare('UPDATE runs SET stderr = stderr || ? WHERE id = ?')
@@ -1109,6 +1104,7 @@ function spawnTurn(input: {
     stallTimer = null
     if (lingerTimer) clearTimeout(lingerTimer)
     lingerTimer = null
+    wakeLock.release()
   }
 
   const kind = eventKindFor(runtimeKind(runtime.bin))
@@ -1465,7 +1461,9 @@ function spawnTurn(input: {
     // agent-opened PR flow can't look green when no PR was created.
     if (status === 'success') {
       const combined = `${row?.stdout ?? ''}\n${row?.stderr ?? ''}`
-      const gh = detectGhFailure(combined)
+      const gh = structuredEvents
+        ? detectGhFailureInEvents(listTurnEventsForMessage(assistantMsgId))
+        : detectGhFailure(combined)
       if (gh.failed) {
         const note = `\n[executor] gh/git reported a failure but the turn exited 0: ${gh.reason}\n`
         appendRunStderr.run(note, runId)
@@ -1588,6 +1586,7 @@ function spawnAcpTurn(input: {
   let stallNotes = 0
   let stallTimer: ReturnType<typeof setInterval> | null = null
   let lingerTimer: ReturnType<typeof setTimeout> | null = null
+  let wakeLock: WakeLock = { release: () => {} }
 
   const appendLog = (stream: 'stdout' | 'stderr', chunk: string) => {
     lastOutputAt = Date.now()
@@ -1779,6 +1778,7 @@ function spawnAcpTurn(input: {
         stallTimer = null
         if (lingerTimer) clearTimeout(lingerTimer)
         lingerTimer = null
+        wakeLock.release()
         persistEvents(coalescer.flush())
         for (const timer of approvalTimers.values()) clearTimeout(timer)
         approvalTimers.clear()
@@ -1813,6 +1813,7 @@ function spawnAcpTurn(input: {
 
   liveMap().set(runId, { child: handle.child, requestStop: () => handle.cancelTurn() })
   db.prepare('UPDATE runs SET pid = ? WHERE id = ?').run(handle.child.pid ?? null, runId)
+  wakeLock = holdWakeLock(handle.child.pid, timeoutMs)
   approvalsMap().set(runId, {
     answer: (rid, answer) => resolveApproval(rid, answer),
     hasPending: () => approvalTimers.size > 0,
@@ -2755,8 +2756,8 @@ export function runTask(
     model: task.model,
     effort: task.effort,
     timeoutMs: task.timeoutMs,
-    resumeSessionId: task.resumeSessionId,
-    resumeSessionLabel: task.resumeSessionLabel,
+    resumeSessionId: resumesSavedSession(trigger) ? task.resumeSessionId : '',
+    resumeSessionLabel: resumesSavedSession(trigger) ? task.resumeSessionLabel : '',
     ...(source ? { source } : {}),
   })
 }

--- a/src/server/integrations/dispatcher.ts
+++ b/src/server/integrations/dispatcher.ts
@@ -111,7 +111,7 @@ function webhookRefusal(task: TaskRow): string | null {
   // Queue that explicit busy condition before health inspection; all other
   // failures are permanent delivery failures and must not be hidden in the
   // queue.
-  return unattendedRefusal(task, runtime)
+  return unattendedRefusal(task, runtime, 'webhook')
 }
 
 function fireTask(task: TaskRow, event: CanonicalWebhookEvent): string {
@@ -137,8 +137,6 @@ function fireTask(task: TaskRow, event: CanonicalWebhookEvent): string {
     model: task.model,
     effort: task.effort,
     timeoutMs: task.timeoutMs,
-    resumeSessionId: task.resumeSessionId,
-    resumeSessionLabel: task.resumeSessionLabel,
     ...(source ? { source } : {}),
   })
 }

--- a/src/server/runEnvironment.test.ts
+++ b/src/server/runEnvironment.test.ts
@@ -13,7 +13,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { after, test } from 'node:test'
 import { createServer } from 'vite'
-import type { RunRow } from './db.ts'
+import type { RunRow, RuntimeRow } from './db.ts'
 
 const appRoot = process.cwd()
 const root = mkdtempSync(join(tmpdir(), 'openrun-executions-'))
@@ -91,6 +91,36 @@ async function terminal(runId: string) {
   throw new Error(`Run did not finish: ${runId}`)
 }
 
+function webhookRun(f: Awaited<ReturnType<typeof fixture>>): string {
+  const runtime = db.prepare('SELECT * FROM runtimes WHERE id = ?').get(f.runtimeId) as RuntimeRow
+  return executor.runTask(f.task, runtime, 'webhook')
+}
+
+test('structured successful diagnostics stay successful while failed GitHub commands fail the run', async () => {
+  for (const exitCode of [0, 1]) {
+    const output = JSON.stringify({
+      type: 'item.completed',
+      item: {
+        id: 'diagnostic',
+        type: 'command_execution',
+        status: 'completed',
+        aggregated_output: 'You are not logged into any GitHub hosts.',
+        exit_code: exitCode,
+      },
+    })
+    const f = await fixture(`console.log(${JSON.stringify(output)})`)
+    const bin = join(root, `runtime-${sequence}`, 'codex')
+    mkdirSync(join(root, `runtime-${sequence}`))
+    writeFileSync(bin, `#!${process.execPath}\nconsole.log(${JSON.stringify(output)})\n`)
+    chmodSync(bin, 0o755)
+    db.prepare('UPDATE runtimes SET bin = ? WHERE id = ?').run(bin, f.runtimeId)
+    const runId = core.runTaskNow(f.task.id).runId
+    const run = await terminal(runId)
+    assert.equal(run.status, exitCode === 0 ? 'success' : 'error', run.stderr)
+    assert.ok(executor.listTurnEventsForRun(runId).some((event) => event.kind === 'tool_result'))
+  }
+})
+
 after(async () => {
   executor.cancelAllLiveRuns()
   const timer = (globalThis as { __openrunMcpTokenTimer?: NodeJS.Timeout }).__openrunMcpTokenTimer
@@ -131,11 +161,15 @@ test('two automation invocations run independently from the same clean base whil
   )
   writeFileSync(join(f.repo, 'source.txt'), 'editor changes')
   writeFileSync(join(f.repo, 'local-only.txt'), 'private local work')
-  const one = core.runTaskNow(f.task.id).runId
-  const two = core.runTaskNow(f.task.id).runId
+  const one = webhookRun(f)
+  const two = webhookRun(f)
   const e1 = environments.getRunEnvironment(one)!
   const e2 = environments.getRunEnvironment(two)!
   assert.notEqual(e1.path, e2.path)
+  assert.deepEqual(
+    workspaces.listWorkspaces(f.project.id).map((w) => w.id),
+    [f.workspace.id],
+  )
   assert.notEqual(e1.branch, e2.branch)
   assert.equal(e1.baseCommit, f.base)
   assert.equal(e2.baseCommit, f.base)
@@ -154,7 +188,7 @@ test('two automation invocations run independently from the same clean base whil
 
 test('successful results, diffs and files survive cleanup and browsing does not recreate directories', async () => {
   const f = await fixture("require('fs').writeFileSync('result.txt', 'saved result\\n')")
-  const runId = core.runTaskNow(f.task.id).runId
+  const runId = webhookRun(f)
   await terminal(runId)
   const env = environments.getRunEnvironment(runId)!
   assert.equal(env.state, 'released')
@@ -191,7 +225,7 @@ test('a follow-up restores the saved result and releases the execution directory
     '[]',
     f.runtimeId,
   )
-  const runId = core.runTaskNow(f.task.id).runId
+  const runId = webhookRun(f)
   await terminal(runId)
   const env = environments.getRunEnvironment(runId)!
   assert.equal(env.state, 'released')
@@ -209,7 +243,7 @@ test('a follow-up restores the saved result and releases the execution directory
 
 test('repeat uses the original base in a new directory after the automation is deleted', async () => {
   const f = await fixture()
-  const first = core.runTaskNow(f.task.id).runId
+  const first = webhookRun(f)
   await terminal(first)
   writeFileSync(join(f.repo, 'source.txt'), 'new base')
   git(f.repo, 'commit', '-qam', 'advance base')
@@ -227,11 +261,11 @@ test('failure preserves partial output without contaminating the next invocation
   const f = await fixture(
     "require('fs').writeFileSync('partial.txt', 'recover me'); process.exit(2)",
   )
-  const runId = core.runTaskNow(f.task.id).runId
+  const runId = webhookRun(f)
   assert.equal((await terminal(runId)).status, 'error')
   const result = environments.getRunEnvironment(runId)!
   assert.equal(git(f.repo, 'show', `${result.resultCommit}:partial.txt`), 'recover me')
-  const retry = core.runTaskNow(f.task.id).runId
+  const retry = webhookRun(f)
   assert.equal(environments.getRunEnvironment(retry)!.baseCommit, f.base)
   await terminal(retry)
 })
@@ -240,7 +274,7 @@ test('cancellation retains uncommitted output until an explicit discard', async 
   const f = await fixture(
     "require('fs').writeFileSync('partial.txt', 'recover me'); setTimeout(() => {}, 30000)",
   )
-  const runId = core.runTaskNow(f.task.id).runId
+  const runId = webhookRun(f)
   const env = environments.getRunEnvironment(runId)!
   const deadline = Date.now() + 5000
   while (!existsSync(join(env.path, 'partial.txt')) && Date.now() < deadline)
@@ -257,14 +291,14 @@ test('cancellation retains uncommitted output until an explicit discard', async 
 
 test('setup failure and cancellation are recorded as part of the run', async () => {
   const f = await fixture('process.exit(0)', `${process.execPath} -e "process.exit(2)"`)
-  const failed = core.runTaskNow(f.task.id).runId
+  const failed = webhookRun(f)
   assert.equal((await terminal(failed)).status, 'error')
   assert.match(core.getRun(failed)!.stderr, /setup failed/)
   workspaces.updateProject({
     id: f.project.id,
     setupCommand: `${process.execPath} -e "setTimeout(() => {}, 30000)"`,
   })
-  const cancelled = core.runTaskNow(f.task.id).runId
+  const cancelled = webhookRun(f)
   executor.cancelRun(cancelled)
   assert.equal((await terminal(cancelled)).status, 'cancelled')
   assert.equal(
@@ -285,7 +319,7 @@ test('setup artifacts are recorded and retained when the agent changes them', as
     setupCommand: `${process.execPath} -e "require('fs').mkdirSync('node_modules'); require('fs').writeFileSync('node_modules/setup.txt', 'from setup')"`,
   })
 
-  const runId = core.runTaskNow(f.task.id).runId
+  const runId = webhookRun(f)
   await terminal(runId)
   const env = environments.getRunEnvironment(runId)!
   assert.match(env.setupArtifacts, /node_modules/)
@@ -295,7 +329,7 @@ test('setup artifacts are recorded and retained when the agent changes them', as
 
 test('cleanup respects leases, worktree locks, ignored user files and external processes', async () => {
   const f = await fixture()
-  const runId = core.runTaskNow(f.task.id).runId
+  const runId = webhookRun(f)
   await terminal(runId)
   environments.ensureRunEnvironment(runId)
   const env = environments.getRunEnvironment(runId)!
@@ -331,7 +365,7 @@ test('cleanup respects leases, worktree locks, ignored user files and external p
 
 test('restart reconciles orphan runs and safely collects journaled clean resources', async () => {
   const f = await fixture()
-  const runId = core.runTaskNow(f.task.id).runId
+  const runId = webhookRun(f)
   await terminal(runId)
   environments.ensureRunEnvironment(runId)
   const env = environments.getRunEnvironment(runId)!
@@ -350,7 +384,7 @@ test('restart reconciles orphan runs and safely collects journaled clean resourc
   assert.equal(existsSync(uncertain.path), true)
 })
 
-test('legacy migration preserves directories and known bases without importing external worktrees', async () => {
+test('legacy migration preserves directories and discovers external worktrees without owning them', async () => {
   const f = await fixture()
   const legacy = await workspaces.createWorkspace({ projectId: f.project.id, branch: 'legacy-run' })
   writeFileSync(join(legacy.path, 'user-work.txt'), 'preserve me')
@@ -368,8 +402,7 @@ test('legacy migration preserves directories and known bases without importing e
   assert.equal(core.getTask(f.task.id)!.baseRef, legacy.baseCommit)
   const external = join(root, 'external')
   git(f.repo, 'worktree', 'add', '-qb', 'external', external)
-  assert.equal(
-    workspaces.listWorkspaces(f.project.id).some((w) => w.path === external),
-    false,
-  )
+  const discovered = workspaces.listWorkspaces(f.project.id).find((w) => w.kind === 'external')
+  assert.equal(discovered?.kind, 'external')
+  assert.throws(() => workspaces.archiveWorkspace(discovered!.id, true), /does not own/)
 })

--- a/src/server/runEnvironment.ts
+++ b/src/server/runEnvironment.ts
@@ -85,7 +85,12 @@ export function getRunEnvironment(runId: string): RunEnvironment | undefined {
     | undefined
 }
 
-export function automationBase(workspaceId: string, requested?: string) {
+function projectForWorkspace(workspaceId: string): {
+  id: string
+  path: string
+  defaultBranch: string
+  setupCommand: string
+} {
   const project = getDb()
     .prepare(`SELECT p.* FROM projects p JOIN workspaces w ON w.projectId = p.id WHERE w.id = ?`)
     .get(workspaceId) as
@@ -94,6 +99,11 @@ export function automationBase(workspaceId: string, requested?: string) {
   if (!project || !existsSync(project.path) || !git.isRepo(project.path)) {
     throw new Error('The project repository is unavailable. Check its folder in Projects.')
   }
+  return project
+}
+
+export function automationBase(workspaceId: string, requested?: string) {
+  const project = projectForWorkspace(workspaceId)
   const baseRef = requested?.trim() || project.defaultBranch
   if (!baseRef || baseRef.startsWith('-') || baseRef.includes('\0'))
     throw new Error('Choose a valid automation base branch or revision.')

--- a/src/server/runQueue.test.ts
+++ b/src/server/runQueue.test.ts
@@ -170,8 +170,7 @@ describe('server pending-run queue', () => {
       .get() as { cwd: string; workspaceId: string; trigger: string } | undefined
     assert.equal(run?.workspaceId, 'workspace-new')
     assert.equal(run?.trigger, 'schedule')
-    assert.notEqual(run?.cwd, newRepo)
-    assert.match(run!.cwd, /executions\/run_/)
+    assert.equal(run?.cwd, newRepo)
 
     const deadline = Date.now() + 2000
     while (Date.now() < deadline) {

--- a/src/server/runQueue.ts
+++ b/src/server/runQueue.ts
@@ -274,7 +274,11 @@ export function drainWorkspace(workspaceId: string): void {
     // This is deliberately the final gate before runTask. It re-reads the
     // exact task.workspaceId represented by the entry and checks lifecycle,
     // PATH, prompt, resume session, health, policy, and ownership together.
-    const unattended = unattendedRefusal(task, runtime)
+    const unattended = unattendedRefusal(
+      task,
+      runtime,
+      entry.trigger === 'webhook' ? 'webhook' : 'schedule',
+    )
     if (unattended) {
       removeEntry(entry.id)
       publishDepth(workspaceId)

--- a/src/server/unattendedPreflight.ts
+++ b/src/server/unattendedPreflight.ts
@@ -11,6 +11,7 @@
  * the lookups those rules need.
  */
 import { automationBaseRefusal } from './runEnvironment.ts'
+import { usesFreshExecution } from '../lib/executionWorkspace.ts'
 import {
   requiresGhAuth,
   unattendedBlockedReason,
@@ -43,7 +44,9 @@ export function unattendedVerificationRefusal(input: {
 }
 
 /** The two automation columns the AFK rules read. */
-export type UnattendedPolicy = Pick<TaskRow, 'requireIsolation' | 'requireGhAuth' | 'baseRef'>
+export type UnattendedPolicy = Pick<TaskRow, 'requireIsolation' | 'requireGhAuth' | 'baseRef'> & {
+  resumeSessionId?: string
+}
 
 /** Reason an unattended fire is unsafe, given an already-inspected workspace. */
 export function unattendedRefusalFor(input: {
@@ -51,15 +54,20 @@ export function unattendedRefusalFor(input: {
   runtime: RuntimeRow
   workspace: WorkspaceRow
   health: WorkspaceHealth
+  trigger?: 'schedule' | 'webhook'
 }): string | null {
-  const baseRefusal = automationBaseRefusal(input.workspace.id, input.task.baseRef)
-  if (baseRefusal) return baseRefusal
+  const webhook = usesFreshExecution(input.trigger ?? 'schedule')
+  if (webhook) {
+    const baseRefusal = automationBaseRefusal(input.workspace.id, input.task.baseRef)
+    if (baseRefusal) return baseRefusal
+  }
   const gh = ghStatus()
   return unattendedBlockedReason({
-    freshExecution: true,
+    freshExecution: webhook,
     workspaceKind: input.workspace.kind,
     requireIsolation: input.task.requireIsolation === 1,
     health: input.health,
+    resumeSessionId: input.task.resumeSessionId,
     requiresGh: requiresGhAuth({
       canOpenPrs: input.runtime.canOpenPrs === 1,
       requireGhAuth: input.task.requireGhAuth === 1,
@@ -74,9 +82,11 @@ export function unattendedRefusalFor(input: {
  * callers that do not already hold a health result. Returns the reason to
  * refuse, or `null` to proceed.
  */
-export function unattendedRefusal(task: TaskRow, runtime: RuntimeRow): string | null {
-  if (task.resumeSessionId?.trim())
-    return 'Automations start a fresh conversation in an isolated checkout. Clear the saved chat before running.'
+export function unattendedRefusal(
+  task: TaskRow,
+  runtime: RuntimeRow,
+  trigger: 'schedule' | 'webhook' = 'schedule',
+): string | null {
   if (!hasWorkspaceId(task.workspaceId)) return `Task ${task.id} has no workspace`
   const verificationRefusal = unattendedVerificationRefusal({
     workspaceId: task.workspaceId,
@@ -89,7 +99,7 @@ export function unattendedRefusal(task: TaskRow, runtime: RuntimeRow): string | 
   if (!checkRuntimeInstalled(runtime.bin).installed) return 'Automation runtime is not on PATH.'
   if (!hasTaskPrompt(task.prompt)) return 'Automation has empty agent instructions.'
 
-  const sessionId = task.resumeSessionId.trim()
+  const sessionId = usesFreshExecution(trigger) ? '' : task.resumeSessionId.trim()
   if (sessionId) {
     const kind = nativeResumeKindFor(runtime)
     if (!kind) return 'The selected runtime does not support resuming a conversation.'
@@ -106,5 +116,6 @@ export function unattendedRefusal(task: TaskRow, runtime: RuntimeRow): string | 
     runtime,
     workspace: checked.workspace,
     health: checked.health,
+    trigger,
   })
 }

--- a/src/server/wakeLock.ts
+++ b/src/server/wakeLock.ts
@@ -1,0 +1,73 @@
+/**
+ * Hold the machine awake for the length of an agent turn.
+ *
+ * A scheduled run fires during macOS's ~45-second dark wake and the laptop is
+ * back in deep sleep long before the CLI has answered — but the wall-clock
+ * budget keeps counting through the sleep, so a 30-minute budget buys a couple
+ * of minutes of real work and then SIGTERMs a perfectly healthy agent.
+ *
+ * The assertion is scoped to the agent's own pid on macOS and bounded by the
+ * turn's budget on Linux, so a crashed server cannot leave a machine pinned
+ * awake.
+ */
+import { spawn } from 'node:child_process'
+
+export type WakeLock = { release: () => void }
+
+const RELEASED: WakeLock = { release: () => {} }
+
+/** Extra slack past the budget before a Linux inhibitor gives up on its own. */
+const INHIBIT_SLACK_MS = 60_000
+
+/** The command that holds the assertion, or null on a platform without one. */
+export function wakeInhibitorArgv(
+  platform: NodeJS.Platform,
+  pid: number,
+  maxMs: number,
+): [string, string[]] | null {
+  // -i holds on battery too; -s is the AC-power system-sleep assertion. The
+  // display is left alone, so the laptop still dims and locks.
+  if (platform === 'darwin') return ['caffeinate', ['-i', '-s', '-w', String(pid)]]
+  if (platform === 'linux') {
+    const seconds = Math.ceil((maxMs + INHIBIT_SLACK_MS) / 1000)
+    return [
+      'systemd-inhibit',
+      [
+        '--what=sleep:idle',
+        '--who=Open Run',
+        '--why=Agent run in progress',
+        '--mode=block',
+        'sleep',
+        String(seconds),
+      ],
+    ]
+  }
+  return null
+}
+
+export function holdWakeLock(pid: number | null | undefined, maxMs: number): WakeLock {
+  if (pid == null || !Number.isFinite(pid) || pid <= 0) return RELEASED
+  const argv = wakeInhibitorArgv(process.platform, pid, maxMs)
+  if (!argv) return RELEASED
+  let child: ReturnType<typeof spawn>
+  try {
+    child = spawn(argv[0], argv[1], { stdio: 'ignore' })
+  } catch {
+    return RELEASED
+  }
+  // A machine without the binary simply sleeps; never fail the run over it.
+  child.on('error', () => {})
+  child.unref()
+  let released = false
+  return {
+    release: () => {
+      if (released) return
+      released = true
+      try {
+        child.kill('SIGTERM')
+      } catch {
+        // Already gone.
+      }
+    },
+  }
+}

--- a/src/server/workspaceHealth.ts
+++ b/src/server/workspaceHealth.ts
@@ -45,7 +45,7 @@ function canonical(p: string): string {
  * `git.isRepo` alone are therefore not a safe restore target.
  */
 export function isRegisteredWorktree(workspace: WorkspaceRow): boolean {
-  if (workspace.kind !== 'worktree') return false
+  if (workspace.kind !== 'worktree' && workspace.kind !== 'external') return false
   const project = getProject(workspace.projectId)
   if (!project) return false
   const wanted = canonical(workspace.path)
@@ -81,7 +81,10 @@ export function inspectWorkspaceHealth(workspace: WorkspaceRow): WorkspaceHealth
   // directory that is a repo but no longer a worktree of this project (someone
   // ran `git worktree remove` and re-created the folder, or the project moved)
   // would have the agent committing into a checkout nothing else tracks.
-  if (workspace.kind === 'worktree' && !isRegisteredWorktree(workspace)) {
+  if (
+    (workspace.kind === 'worktree' || workspace.kind === 'external') &&
+    !isRegisteredWorktree(workspace)
+  ) {
     return at(workspace, 'not-a-worktree')
   }
 
@@ -247,15 +250,14 @@ export type RestoreResult = {
  * Put an app-managed worktree back on its configured branch with a clean tree
  * and lift its quarantine.
  *
- * Never touches a `kind='main'` workspace: that is the user's own checkout,
- * and a hard reset there would delete work this app did not create.
+ * Only app-managed worktrees may be restored; external checkouts are user-owned too.
  */
 export function restoreWorkspace(workspaceId: string): RestoreResult {
   const workspace = getWorkspace(workspaceId)
   if (!workspace) throw new Error('Workspace not found')
-  if (workspace.kind === 'main') {
+  if (workspace.kind !== 'worktree') {
     throw new Error(
-      'Cannot restore the main checkout — it is your own working copy. Commit or discard its changes yourself.',
+      'Cannot restore this checkout because Open Run does not own it. Commit or discard its changes yourself.',
     )
   }
   const active = getDb()

--- a/src/server/workspaces.test.ts
+++ b/src/server/workspaces.test.ts
@@ -43,7 +43,7 @@ after(async () => {
 })
 
 describe('Git worktree reconciliation', () => {
-  it('keeps a stable project checkout without importing external worktrees', async () => {
+  it('keeps the primary checkout stable and registers external worktrees as user-owned', async () => {
     const project = await workspaces.addProject({ mode: 'register', path: repo })
     const [main] = workspaces.listWorkspaces(project.id)
     assert.equal(main?.kind, 'main')
@@ -66,8 +66,11 @@ describe('Git worktree reconciliation', () => {
       cwd: repo,
     })
     const imported = workspaces.listWorkspaces(project.id)
-    assert.equal(imported.length, 1)
-    assert.equal(imported[0]?.id, main!.id)
+    assert.equal(imported.length, 2)
+    const external = imported.find((workspace) => workspace.kind === 'external')
+    assert.equal(external?.path, realpathSync(manualWorktree))
+    assert.equal(external?.branch, 'feature/manual')
+    assert.throws(() => workspaces.archiveWorkspace(external!.id, true), /does not own/)
 
     execFileSync('git', ['worktree', 'remove', manualWorktree], { cwd: repo })
     assert.deepEqual(

--- a/src/server/workspaces.ts
+++ b/src/server/workspaces.ts
@@ -1,6 +1,6 @@
 /** Project checkouts and legacy workspace compatibility metadata.
  * New automation execution directories belong to runs (runEnvironment.ts).
- * Never discover ownership from a Git worktree name or import the inventory.
+ * Git's inventory discovers external worktrees, while `kind` records ownership.
  */
 import { spawnSync } from 'node:child_process'
 import { runCommand } from './command.ts'
@@ -126,6 +126,10 @@ export function reconcileWorkspaces(projectId?: string): void {
     `INSERT INTO workspaces (id, projectId, name, branch, path, kind, status, setupLog, setupExitCode, blockedKind, blockedReason, blockedAt, baseCommit, createdAt, archivedAt)
      VALUES (@id, @projectId, 'main checkout', @branch, @path, 'main', 'ready', '', NULL, '', '', 0, @baseCommit, @createdAt, NULL)`,
   )
+  const insertExternal = db.prepare(
+    `INSERT INTO workspaces (id, projectId, name, branch, path, kind, status, setupLog, setupExitCode, blockedKind, blockedReason, blockedAt, baseCommit, createdAt, archivedAt)
+     VALUES (@id, @projectId, @name, @branch, @path, 'external', 'ready', '', NULL, '', '', 0, @baseCommit, @createdAt, NULL)`,
+  )
   const refreshMain = db.prepare(
     `UPDATE workspaces
      SET branch = ?, path = ?, status = 'ready', setupLog = '', setupExitCode = NULL,
@@ -139,10 +143,18 @@ export function reconcileWorkspaces(projectId?: string): void {
     if (!inventory.ok) continue
 
     const primaryPath = canonicalPath(project.path)
+    const executionPaths = new Set(
+      (
+        db.prepare('SELECT path FROM run_environments WHERE projectId = ?').all(project.id) as {
+          path: string
+        }[]
+      ).map((row) => canonicalPath(row.path)),
+    )
     const primaryBranch = git.currentBranch(project.path)
     const registered = inventory.entries.filter(
       (entry) =>
         !entry.bare &&
+        !executionPaths.has(canonicalPath(entry.path)) &&
         canonicalPath(entry.path) !== primaryPath &&
         // Some repository layouts (notably submodules with core.worktree)
         // report the primary entry using the common Git-directory path. The
@@ -152,8 +164,23 @@ export function reconcileWorkspaces(projectId?: string): void {
     )
     const registeredPaths = new Set(registered.map((entry) => canonicalPath(entry.path)))
     const recorded = db
-      .prepare("SELECT * FROM workspaces WHERE projectId = ? AND kind = 'worktree'")
+      .prepare("SELECT * FROM workspaces WHERE projectId = ? AND kind IN ('worktree', 'external')")
       .all(project.id) as WorkspaceRow[]
+    const recordedPaths = new Set(recorded.map((workspace) => canonicalPath(workspace.path)))
+
+    for (const entry of registered) {
+      const entryPath = canonicalPath(entry.path)
+      if (recordedPaths.has(entryPath)) continue
+      insertExternal.run({
+        id: id('ws'),
+        projectId: project.id,
+        name: path.basename(entryPath),
+        branch: entry.branch || 'HEAD',
+        path: entryPath,
+        baseCommit: entry.head || git.resolveCommit(entryPath, 'HEAD'),
+        createdAt: Date.now(),
+      })
+    }
 
     // Interactive chats may deliberately share the checkout open in the
     // user's editor. Keep one stable row for it, but never treat it as an
@@ -738,8 +765,8 @@ export function archiveWorkspace(
   // The 'main' workspace is the user's own checkout, shared with their
   // editor — archiving (and removing the worktree of) it would delete work
   // the app never created and doesn't own.
-  if (workspace.kind === 'main') {
-    throw new Error('Cannot archive the main checkout — this is your own working copy')
+  if (workspace.kind === 'main' || workspace.kind === 'external') {
+    throw new Error('Cannot archive a checkout that Open Run does not own')
   }
 
   const project = getProject(workspace.projectId)
@@ -769,7 +796,7 @@ export function resolveWorkspacePath(workspaceId: string): string {
   const workspace = getWorkspace(workspaceId)
   if (!workspace) throw new Error('Workspace not found')
   const project = getProject(workspace.projectId)
-  if (workspace.kind !== 'worktree' && workspace.kind !== 'main') {
+  if (workspace.kind !== 'worktree' && workspace.kind !== 'main' && workspace.kind !== 'external') {
     throw new Error('Unsupported workspace kind')
   }
   // Chat already refused non-ready workspaces; automations used to only check
@@ -786,7 +813,11 @@ export function resolveWorkspacePath(workspaceId: string): string {
       .run(message, workspace.id)
     throw new Error(message)
   }
-  if (workspace.kind === 'worktree' && project && git.isRepo(project.path)) {
+  if (
+    (workspace.kind === 'worktree' || workspace.kind === 'external') &&
+    project &&
+    git.isRepo(project.path)
+  ) {
     const inventory = git.inspectWorktrees(project.path)
     const registered = inventory.entries.some(
       (entry) => !entry.bare && canonicalPath(entry.path) === canonicalPath(workspace.path),


### PR DESCRIPTION
## Summary

- Keep manual and scheduled automations in their selected workspace so saved CLI conversations continue with their existing files and context. The automation form now offers saved chats and an actual workspace selector; webhook deliveries retain a fresh conversation and isolated checkout from the configured base. Scheduled runs without a saved chat still refuse dirty workspaces, while resumed chats may retain edits and branch changes without bypassing missing-directory or quarantine checks.
- Make workspace choices and readiness match execution: discover external Git worktrees as user-owned checkouts, refuse to archive or reset them, and exclude temporary execution directories from discovery. Share resumed-chat health rules between the UI and unattended preflight so a ready-looking automation does not fail a different check when it fires.
- Hold a best-effort sleep inhibitor during CLI and ACP turns on macOS and Linux, releasing it when the turn ends. This addresses runs exhausting their wall-clock budget while the machine is idle-asleep; unavailable inhibitor utilities do not prevent a run from starting.
- Stop marking successful structured runs as failed merely because they read an old GitHub authentication error from logs or source code. Inspect failed tool results instead of scanning the entire transcript; actual failed GitHub commands remain errors, and plain-output runtimes retain the fallback detector. The historical failed run is not rewritten.

## Test plan

- [ ] On `/tasks/new`, select a project and a saved chat from the runtime picker. Confirm the chat's workspace is selected and an empty prompt receives continuation instructions. Save and use Run now; verify the run resumes the saved conversation in that checkout with its existing files.
- [ ] On the automation detail page, select a different workspace. Confirm the saved-chat selection clears and manual execution uses the selected checkout. Schedule a saved-chat continuation with uncommitted edits; verify it starts, while a new-conversation schedule on that dirty checkout is refused with an explanation. A missing or quarantined workspace must still block the saved-chat schedule.
- [ ] With one run holding a workspace, let a second scheduled fire queue. Confirm it starts only after the first releases the workspace and rechecks readiness before starting.
- [ ] On an integration automation, select a base branch and send two webhook test events while the source checkout has local edits. Confirm deliveries use separate execution worktrees from the base, start fresh conversations, and leave the source edits intact. Confirm those temporary directories do not appear in `/runs/new` workspace choices.
- [ ] Create a Git worktree outside Open Run for a registered project, then open `/runs/new` and the automation editor. Confirm it is available as a workspace, can run an interactive chat, and cannot be archived or restored by Open Run. Remove the worktree after finishing the chat and verify it is no longer offered as ready.
- [ ] On macOS, start a long-running CLI turn and inspect `pmset -g assertions`; confirm a sleep assertion exists during the turn and disappears after completion or cancellation. Repeat with an ACP runtime. On Linux with `systemd-inhibit` available, check `systemd-inhibit --list` for equivalent acquisition and release. Confirm the display can still dim and lock.
- [ ] On `/runs/new` with a runtime that emits structured tool events, run a successful command that prints `You are not logged into any GitHub hosts.` from a fixture or old log. Confirm the run stays successful. Repeat with the same output and a nonzero command exit, allowing the turn itself to exit zero; confirm the run reports the GitHub failure. No account sign-out is needed.
- [ ] Finish an isolated webhook run, inspect its diff/files, and send a follow-up. Confirm saved output survives cleanup and the follow-up restores its execution checkout. Cancel a run after it writes a file and verify partial output remains recoverable.
